### PR TITLE
Loaders: load JSON and Yaml files

### DIFF
--- a/src/Config/Loader/FileLoader/FileLoaderAbstract.php
+++ b/src/Config/Loader/FileLoader/FileLoaderAbstract.php
@@ -1,0 +1,76 @@
+<?php
+namespace Cascade\Config\Loader\FileLoader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+
+/**
+ * Abstract class that reads input from various sources: file, string or array
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+abstract class FileLoaderAbstract extends FileLoader
+{
+    public static $validExtensions = array();
+
+    /**
+     * Read from a file or string
+     * @throws RuntimeException if the file is not readable
+     *
+     * @param  string $input Filepath or string
+     * @return atring return a string
+     */
+    public function readFrom($input)
+    {
+        if ($this->isFile($input)) {
+            if (is_readable($input) === false) {
+                throw new \RuntimeException(
+                    sprintf('Unable to parse "%s" as the file is not readable.', $input)
+                );
+            }
+
+            // $input is a filepath, so we load that file
+            $input = file_get_contents($input);
+        }
+
+        return trim($input);
+    }
+
+    /**
+     * Test if a given resource is a file name or a file path
+     *
+     * @param  string $resource Plain string or file path
+     * @return boolean whether or not the resource is a file
+     */
+    public function isFile($resource)
+    {
+        return (strpos($resource, "\n") === false) && is_file($resource);
+    }
+
+    /**
+     * Validate a file extension against a list of provided valid extensions
+     *
+     * @param  string $filepath file path of the file we want to check
+     * @return boolean whether or no the extension is valid
+     */
+    public function validateExtension($filepath)
+    {
+        return in_array(pathinfo($filepath, PATHINFO_EXTENSION), static::$validExtensions, true);
+    }
+
+    /**
+     * Return a section of an array based on the key passed in
+     *
+     * @param  array $array Array we want the section from
+     * @param  string $section Section name (key)
+     *
+     * @return array | mixed   return the section of an array or just a value
+     */
+    public function getSectionOf($array, $section = '')
+    {
+        if (!empty($section) && array_key_exists($section, $array)) {
+            return $array[$section];
+        }
+
+        return $array;
+    }
+}

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -1,0 +1,68 @@
+<?php
+namespace Cascade\Config\Loader\FileLoader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+
+/**
+ * JSON loader class. It can load a JSON string or a Yaml file
+ * @see FileLoaderAbstract
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class Json extends FileLoaderAbstract
+{
+    /**
+     * Valid file extensions for this loader
+     * @var array
+     */
+    public static $validExtensions = array('json');
+
+    /**
+     * Load a JSON string/file
+     *
+     * @param  string $resource JSON string or file path to a JSON file
+     * @param  string|null $type This is not used.
+     * @return array array containing data from the parsed JSON string or file
+     */
+    public function load($resource, $type = null)
+    {
+        return json_decode($this->readFrom($resource), true);
+    }
+
+    /**
+     * Determine whether a given string is supposed to be a Json string
+     * This is a very simplified validation to avoid calling
+     * json_decode (which is much more expensive). If the json is invalid, it will throw an
+     * exception when we actually load it.
+     *
+     * @param  string  $string String to evaluate
+     * @return boolean whether or not the passed string is meant to be a JSON string
+     */
+    private function isJson($string)
+    {
+        return (
+            !empty($string) &&
+            ($string{0} === '[' || $string{0} === '{')
+        );
+    }
+
+    /**
+     * Return whether or not the passed in resrouce is supported by this loader
+     *
+     * @param  string $resource plain string or filepath
+     * @param  string $type not used
+     * @return boolean whether or not the passed in resource is supported by this loader
+     */
+    public function supports($resource, $type = null)
+    {
+        if (is_string($resource)) {
+            if ($this->isFile($resource)) {
+                return $this->validateExtension($resource);
+            } else {
+                return $this->isJson($resource);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Config/Loader/FileLoader/Yaml.php
+++ b/src/Config/Loader/FileLoader/Yaml.php
@@ -1,0 +1,55 @@
+<?php
+namespace Cascade\Config\Loader\FileLoader;
+
+use Symfony\Component\Yaml\Yaml as YamlParser;
+
+/**
+ * Yaml loader class. It can load a Yaml string or a Yaml file
+ * @see FileLoaderAbstract
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class Yaml extends FileLoaderAbstract
+{
+    /**
+     * Valid file extensions for this loader
+     * @var array
+     */
+    public static $validExtensions = array(
+        'yaml', // official extension
+        'yml' // but everybody uses that one
+    );
+
+    /**
+     * Load a Yaml string/file
+     *
+     * @param  string $resource  Yaml string or file path to a Yaml file
+     * @param  string|null $type This is not used
+     * @return array             array containing data from the parse Yaml string or file
+     */
+    public function load($resource, $type = null)
+    {
+        return YamlParser::parse($this->readFrom($resource));
+    }
+
+    /**
+     * Return whether or not the resource passed in is supported by this loader
+     * /!\ This does not validate Yaml content. The parser will raise an exception in that case
+     *
+     * @param  string $resource plain string or filepath
+     * @param  string $type     not used
+     * @return boolean          whether or not the passed in resrouce is supported by this loader
+     */
+    public function supports($resource, $type = null)
+    {
+        if (!is_string($resource)) {
+            return false;
+        }
+
+        if ($this->isFile($resource)) {
+            return $this->validateExtension($resource);
+        }
+
+        return true;
+    }
+}

--- a/src/Config/Loader/PhpArray.php
+++ b/src/Config/Loader/PhpArray.php
@@ -1,0 +1,37 @@
+<?php
+namespace Cascade\Config\Loader;
+
+use Symfony\Component\Config\Loader\Loader;
+
+/**
+ * Array loader class. It loads a php array
+ * @see Loader
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class PhpArray extends Loader
+{
+    /**
+     * Loads an array
+     *
+     * @param  array $array Array to load
+     * @param  string|null $type This is not used.
+     * @return array The passed in array
+     */
+    public function load($array, $type = null)
+    {
+        return $array;
+    }
+
+    /**
+     * Return whether or not the passed in resource is supported by this loader
+     *
+     * @param  string $resource plain string or filepath
+     * @param  string $type     resource type
+     * @return boolean          whether or not the passed in resrouce is supported by this loader
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_array($resource);
+    }
+}

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -1,0 +1,154 @@
+<?php
+namespace Cascade\Tests\Config\Loader\FileLoader;
+
+use org\bovigo\vfs\vfsStream;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\FileLocatorInterface;
+
+use Cascade\Tests\Fixtures;
+
+/**
+ * Class FileLoaderAbstractTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
+{
+    protected $mock = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $fileLocatorMock = $this->getMock(
+            'Symfony\Component\Config\FileLocatorInterface'
+        );
+
+        $this->mock = $this->getMockForAbstractClass(
+            'Cascade\Config\Loader\FileLoader\FileLoaderAbstract',
+            array($fileLocatorMock),
+            'FileLoaderAbstractMockClass' // mock class name
+        );
+
+        // Setting valid extensions for tests
+        \FileLoaderAbstractMockClass::$validExtensions = array('test', 'php');
+    }
+
+    public function tearDown()
+    {
+        $this->mock = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Test loading config from a valid file
+     */
+    public function testReadFrom()
+    {
+        $this->assertEquals(
+            Fixtures::getSampleYamlString(),
+            $this->mock->readFrom(Fixtures::getSampleYamlFile())
+        );
+    }
+
+    /**
+     * Test loading config from a valid file
+     */
+    public function testLoadFileFromString()
+    {
+        $this->assertEquals(
+            trim(Fixtures::getSampleString()),
+            $this->mock->readFrom(Fixtures::getSampleString())
+        );
+    }
+
+    /**
+     * Data provider for testGetSectionOf
+     * @return array array with original value, section and expected value
+     */
+    public function extensionsDataProvider()
+    {
+        return array(
+            array(true, 'hello/world.test'),
+            array(true, 'hello/world.php'),
+            array(false, 'hello/world.jpeg'),
+            array(false, 'hello/world'),
+            array(false, '')
+        );
+    }
+
+    /**
+     * Test validating the extension
+     *
+     * @dataProvider extensionsDataProvider
+     */
+    public function testValidateExtension($expected, $filepath)
+    {
+        if ($expected) {
+            $this->assertTrue($this->mock->validateExtension($filepath));
+        } else {
+            $this->assertFalse($this->mock->validateExtension($filepath));
+        }
+    }
+
+    /**
+     * Data provider for testGetSectionOf
+     * @return array array wit original value, section and expected value
+     */
+    public function arrayDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    'a' => array('aa' => 'AA', 'ab' => 'AB'),
+                    'b' => array('ba' => 'BA', 'bb' => 'BB')
+                ),
+                'b',
+                array('ba' => 'BA', 'bb' => 'BB')
+            ),
+            array(
+                array('a' => 'A', 'b' => 'B'),
+                'c',
+                array('a' => 'A', 'b' => 'B'),
+            ),
+            array(
+                array('a' => 'A', 'b' => 'B'),
+                '',
+                array('a' => 'A', 'b' => 'B'),
+            )
+        );
+    }
+
+    /**
+     * Test the getSectionOf function
+     *
+     * @dataProvider arrayDataProvider
+     */
+    public function testGetSectionOf($array, $section, $expected)
+    {
+        $this->assertSame($expected, $this->mock->getSectionOf($array, $section));
+    }
+
+    /**
+     * Test loading an invalid file
+     *
+     * @expectedException RuntimeException
+     */
+    public function testloadFileFromInvalidFile()
+    {
+        // mocking the file system from a 'config_dir' base dir
+        $root = vfsStream::setup('config_dir');
+
+        // Adding an unreadable file (chmod 0000)
+        vfsStream::newFile('config.yml', 0000)
+            ->withContent(
+                "---\n".
+                "hidden_config: true"
+            )->at($root);
+
+        // This will throw an exception because the file is not readable
+        $this->mock->readFrom(vfsStream::url('config_dir/config.yml'));
+
+        stream_wrapper_unregister(vfsStream::SCHEME);
+    }
+}

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -1,0 +1,132 @@
+<?php
+namespace Cascade\Tests\Config\Loader\FileLoader;
+
+use Cascade\Config\Loader\FileLoader\Json as JsonLoader;
+use Cascade\Tests\Fixtures;
+
+/**
+ * Class JsonTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class JsonTest extends \PHPUnit_Framework_TestCase
+{
+    protected $jsonLoader = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $fileLocatorMock = $this->getMock(
+            'Symfony\Component\Config\FileLocatorInterface'
+        );
+
+        $this->jsonLoader = $this->getMockBuilder(
+            'Cascade\Config\Loader\FileLoader\Json'
+        )
+            ->setConstructorArgs(array($fileLocatorMock))
+            ->setMethods(array('readFrom', 'isFile', 'validateExtension'))
+            ->getMock();
+    }
+
+    public function tearDown()
+    {
+        $this->jsonLoader = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Test loading a JSON string
+     */
+    public function testLoad()
+    {
+        $json = Fixtures::getSampleJsonString();
+
+        $this->jsonLoader->expects($this->once())
+            ->method('readFrom')
+            ->willReturn($json);
+
+        $this->assertEquals(
+            json_decode($json, true),
+            $this->jsonLoader->load($json)
+        );
+    }
+
+    /**
+     * Data provider for testSupportsWithInvalidResource
+     * @return array array non-string values
+     */
+    public function notStringDataProvider()
+    {
+        return array(
+            array(array()),
+            array(true),
+            array(123),
+            array(123.456),
+            array(null),
+            array(new \stdClass),
+            // array(function () {
+            // })
+            // cannot test Closure type because of PhpUnit
+            // @see https://github.com/sebastianbergmann/phpunit/issues/451
+        );
+    }
+
+    /**
+     * Test loading resources supported by the JsonLoader
+     *
+     * @dataProvider notStringDataProvider
+     */
+    public function testSupportsWithInvalidResource($invalidResource)
+    {
+        $this->assertFalse($this->jsonLoader->supports($invalidResource));
+    }
+
+    /**
+     * Test loading a JSON string
+     */
+    public function testSupportsWithJsonString()
+    {
+        $this->jsonLoader->expects($this->once())
+            ->method('isFile')
+            ->willReturn(false);
+
+        $json = Fixtures::getSampleJsonString();
+
+        $this->assertTrue($this->jsonLoader->supports($json));
+    }
+
+    /**
+     * Test loading a JSON file
+     * Note that this function tests isJson with a valid Json string
+     */
+    public function testSupportsWithJsonFile()
+    {
+        $this->jsonLoader->expects($this->once())
+            ->method('isFile')
+            ->willReturn(true);
+
+        $this->jsonLoader->expects($this->once())
+            ->method('validateExtension')
+            ->willReturn(true);
+
+        $jsonFile = Fixtures::getSampleJsonFile();
+
+        $this->assertTrue($this->jsonLoader->supports($jsonFile));
+    }
+
+    /**
+     * Test isJson method with invalid JSON string.
+     * Valid scenario is tested by the method above
+     */
+    public function testSupportsWithNonJsonString()
+    {
+        $this->jsonLoader->expects($this->once())
+            ->method('isFile')
+            ->willReturn(false);
+
+        $someString = Fixtures::getSampleString();
+
+        $this->assertFalse($this->jsonLoader->supports($someString));
+    }
+}

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Cascade\Tests\Config\Loader;
+
+use Cascade\Config\Loader\PhpArray as ArrayLoader;
+use Cascade\Tests\Fixtures;
+
+/**
+ * Class PhpArrayTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class PhpArrayTest extends \PHPUnit_Framework_TestCase
+{
+    protected $arrayLoader = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->arrayLoader = new ArrayLoader();
+    }
+
+    public function tearDown()
+    {
+        $this->arrayLoader = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Test loading a Php array
+     */
+    public function testLoad()
+    {
+        $array = Fixtures::getSamplePhpArray();
+        $this->assertSame($array, $this->arrayLoader->load($array));
+    }
+
+    /**
+     * Data provider for testSupportsWithInvalidResource
+     * @return array array of non-array values
+     */
+    public function notStringDataProvider()
+    {
+        return array(
+            array('Some string'),
+            array(true),
+            array(123),
+            array(123.456),
+            array(null),
+            array(new \stdClass),
+            // array(function () {
+            // })
+            // cannot test Closure type because of PhpUnit
+            // @see https://github.com/sebastianbergmann/phpunit/issues/451
+        );
+    }
+
+    /**
+     * Test loading resources supported by the YamlLoader
+     *
+     * @dataProvider notStringDataProvider
+     */
+    public function testSupportsWithInvalidResource($invalidResource)
+    {
+        $this->assertFalse($this->arrayLoader->supports($invalidResource));
+    }
+
+    /**
+     * Test supports with a valid array
+     */
+    public function testSupports()
+    {
+        $array = Fixtures::getSamplePhpArray();
+        $this->assertTrue($this->arrayLoader->supports($array));
+    }
+
+}


### PR DESCRIPTION
Load JSON, Yaml or PhpArray
For files it is using [Symfony's FIleLoader](https://github.com/symfony/Config/blob/master/Loader/FileLoader.php). The `FileLoaderAbstract` extends that class.

Note: `FileLoaderAbstract` uses late static binding to get the extensions from the child class.

This is used to load the logger config from various resources.

Will add .ini support in the future

@mortaliorchard @OrCharles