### PR TITLE
Added option resolvers for Constructor params and additional options

### DIFF
--- a/src/Config/Loader/ClassLoader.php
+++ b/src/Config/Loader/ClassLoader.php
@@ -1,0 +1,231 @@
+<?php
+namespace Cascade\Config\Loader;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
+use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
+
+/**
+ * Class Loader. Instantiate an object given a set of options. The option might look like:
+ *     array(
+ *         'class' => 'Some\Class'
+ *         'some_contruct_param' => 'abc',
+ *         'some_param' => 'def',
+ *         'some_other_param' => 'sdsad'
+ *     )
+ *
+ * Some of them are applicable to the contructor, other are applicable to other handlers.
+ * For the latter you need to make sure there is a handler defined for that option
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ClassLoader
+{
+    /**
+     * Default class to use if none is provided in the option array
+     */
+    const DEFAULT_CLASS = '\stdClass';
+
+    /**
+     * Array of Closures indexed by class.
+     *     array(
+     *         '\Full\Absolute\Namespace\ClassName' => array(
+     *             'myOption' => Closure
+     *         ), ...
+     *     )
+     * @var array
+     */
+    public static $extraOptionHandlers = array();
+
+    /**
+     * Name of the class you want to load
+     * @var String
+     */
+    public $class = null;
+
+    /**
+     * Reflected object of the class passed in
+     * @var ReflectionClass
+     */
+    protected $reflected = null;
+
+    /**
+     * Array of options. This is a raw copy of the options passed in.
+     * @var array
+     */
+    protected $rawOptions = array();
+
+    /**
+     * Constructor
+     *
+     * @param array $options array of options
+     * The option array might look like:
+     *     array(
+     *         'class' => 'Some\Class',
+     *         'some_contruct_param' => 'abc',
+     *         'some_param' => 'def',
+     *         'some_other_param' => 'sdsad'
+     *     )
+     */
+    public function __construct(array $options)
+    {
+        $this->rawOptions = self::optionsToCamelCase($options);
+        $this->setClass();
+        $this->reflected = new \ReflectionClass($this->class);
+    }
+
+    /**
+     * Set the class you want to load from the raw option array
+     */
+    protected function setClass()
+    {
+        if (!isset($this->rawOptions['class'])) {
+            $this->rawOptions['class'] = static::DEFAULT_CLASS;
+        }
+
+        $this->class = $this->rawOptions['class'];
+        unset($this->rawOptions['class']);
+    }
+
+    /**
+     * Return option values indexed by name using camelCased keys
+     *
+     * @param  array  $options array of options
+     * @return mixed[] array of options indexed by (camelCased) name
+     */
+    public static function optionsToCamelCase(array $options)
+    {
+        $optionsByName = array();
+
+        if (count($options)) {
+            $nameConverter = new CamelCaseToSnakeCaseNameConverter();
+
+            foreach ($options as $name => $value) {
+                $optionsByName[$nameConverter->denormalize($name)] = $value;
+            }
+        }
+
+        return $optionsByName;
+    }
+
+    /**
+     * Resolve options and returns them into 2 buckets:
+     *   - constructor options and
+     *   - extra options
+     * Extra options are those that are not in the contructor. The constructor arguments determine
+     * what goes into which bucket
+     *
+     * @return array array of constructorOptions and extraOptions
+     */
+    private function resolveOptions()
+    {
+        $constructorResolver = new ConstructorResolver($this->reflected);
+
+        // Contructor options are only the ones matching the contructor args' names
+        $constructorOptions = array_intersect_key(
+            $this->rawOptions,
+            $constructorResolver->getConstructorArgs()
+        );
+
+        // Extra options are everything else than contructor options
+        $extraOptions = array_diff_key(
+            $this->rawOptions,
+            $constructorOptions
+        );
+
+        $extraOptionsResolver = new ExtraOptionsResolver(
+            $this->reflected,
+            array_keys($extraOptions)
+        );
+
+        return array(
+            $constructorResolver->resolve($constructorOptions),
+            $extraOptionsResolver->resolve($extraOptions, $this)
+        );
+    }
+
+    /**
+     * Instantiate the reflected object using the parsed contructor args and set
+     * extra options if any
+     *
+     * @return mixed instance of the reflected object
+     */
+    public function load()
+    {
+        list($constructorResolvedOptions, $extraResolvedOptions) = $this->resolveOptions();
+        $instance = $this->reflected->newInstanceArgs($constructorResolvedOptions);
+
+        $this->loadExtraOptions($extraResolvedOptions, $instance);
+
+        return $instance;
+    }
+
+    /**
+     * Indicates whether or not an option is supported by the loader
+     *
+     * @param  string $extraOptionName Option name
+     * @return boolean whether or not an option is supported by the loader
+     */
+    public function canHandle($extraOptionName)
+    {
+        return
+            isset(self::$extraOptionHandlers['*'][$extraOptionName]) ||
+            isset(self::$extraOptionHandlers[$this->class][$extraOptionName]);
+    }
+
+    /**
+     * Get the corresponding handler for a given option
+     *
+     * @param  string $extraOptionName Option name
+     * @return Closure|null Corresponding Closure object or null if not found
+     */
+    public function getExtraOptionsHandler($extraOptionName)
+    {
+        // Check extraOption handlers that are valid for all classes
+        if (isset(self::$extraOptionHandlers['*'][$extraOptionName])) {
+            return self::$extraOptionHandlers['*'][$extraOptionName];
+        }
+
+        // Check extraOption handlers that are valid for the given class
+        if (isset(self::$extraOptionHandlers[$this->class][$extraOptionName])) {
+            return self::$extraOptionHandlers[$this->class][$extraOptionName];
+        }
+
+        return null;
+    }
+
+    /**
+     * Set extra options if any were requested
+     *
+     * @param  array $extraOptions Array of extra options (key => value)
+     * @param  mixed $instance Instance you want to set options for
+     */
+    public function loadExtraOptions($extraOptions, $instance)
+    {
+        foreach ($extraOptions as $name => $value) {
+            if ($this->reflected->hasMethod($name)) {
+                // There is a method to handle this option
+                call_user_func_array(
+                    array($instance, $name),
+                    is_array($value) ? $value : array($value)
+                );
+                continue;
+            }
+            if ($this->reflected->hasProperty($name) &&
+                $this->reflected->getProperty($name)->isPublic()
+            ) {
+                // There is a public member we can set for this option
+                $instance->$name = $value;
+                continue;
+            }
+
+            if ($this->canHandle($name)) {
+                // There is a custom handler for that option
+                $closure = $this->getExtraOptionsHandler($name);
+                $closure($instance, $value);
+            }
+        }
+    }
+}

--- a/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
@@ -1,0 +1,142 @@
+<?php
+namespace Cascade\Config\Loader\ClassLoader\Resolver;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Constructor Resolver. Pull args from the contructor and set up an option
+ * resolver against args requirements
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ConstructorResolver
+{
+    /**
+     * Reflection class for which you want to resolve constructor options
+     *
+     * @var \ReflectionClass
+     */
+    protected $reflected = null;
+
+    /**
+     * Registry of resolvers
+     *
+     * @var array
+     */
+    private static $resolvers = array();
+
+    /**
+     * Associative array of contructor args to resolve against
+     * @var \ReflectionParameter[]
+     */
+    protected $constructorArgs = array();
+
+    /**
+     * Contructor
+     *
+     * @param \ReflectionClass $reflected Reflection class for which you want to resolve
+     * constructor options
+     */
+    public function __construct(\ReflectionClass $reflected)
+    {
+        $this->reflected = $reflected;
+        $this->initConstructorArgs();
+    }
+
+    /**
+     * Fetches constructor args (array of ReflectionParameter) from the reflected class
+     * and set them as an associative array
+     */
+    public function initConstructorArgs()
+    {
+        $constructor = $this->reflected->getConstructor();
+
+        if (!is_null($constructor)) {
+            // Index parameters by their names
+            foreach ($constructor->getParameters() as $param) {
+                $this->constructorArgs[$param->getName()] = $param;
+            }
+        }
+    }
+
+    /**
+     * Returns the contructor args as an associative array
+     *
+     * @return array Contructor args
+     */
+    public function getConstructorArgs()
+    {
+        return $this->constructorArgs;
+    }
+
+    /**
+     * Returns the reflected object
+     *
+     * @return \ReflectionClass
+     */
+    public function getReflected()
+    {
+        return $this->reflected;
+    }
+
+    /**
+     * Configure options for the provided OptionResolver to match contructor args requirements
+     *
+     * @param  OptionsResolver $optionsResolver OptionResolver to configure
+     */
+    protected function configureOptions(OptionsResolver $optionsResolver)
+    {
+        foreach ($this->constructorArgs as $name => $param) {
+            if ($param->isOptional()) {
+                $optionsResolver->setDefault($name, $param->getDefaultValue());
+            } else {
+                $optionsResolver->setRequired($name);
+            }
+        }
+    }
+
+    /**
+     * Loops through constructor args and buid an ordered array of args using
+     * the option values passed in. We assume the passed in array has been resolved already.
+     * i.e. That the arg name has an entry in the option array.
+     *
+     * @param  array $hashOfOptions array of options
+     * @return array array of ordered args
+     */
+    public function hashToArgsArray($hashOfOptions)
+    {
+        $optionsArray = new \SplFixedArray(count($hashOfOptions));
+
+        foreach ($this->constructorArgs as $name => $param) {
+            $optionsArray[$param->getPosition()] = $hashOfOptions[$name];
+        }
+
+        return $optionsArray->toArray();
+    }
+
+    /**
+     * Resolve options against constructor args
+     *
+     * @param  array $options Array of option values. Expected array looks like:
+     *     array(
+     *         'someParam' => 'def',
+     *         'someOtherParam' => 'sdsad'
+     *     )
+     * @return array array of resolved ordered args
+     */
+    public function resolve(array $options)
+    {
+        $reflectedClassName = $this->reflected->getName();
+
+        // We check if that constructor has been configured before and is in the registry
+        if (!isset(self::$resolvers[$reflectedClassName])) {
+            self::$resolvers[$reflectedClassName] = new OptionsResolver();
+
+            $this->configureOptions(self::$resolvers[$reflectedClassName]);
+        }
+
+        return $this->hashToArgsArray(
+            self::$resolvers[$reflectedClassName]->resolve($options)
+        );
+    }
+}

--- a/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
@@ -1,0 +1,141 @@
+<?php
+namespace Cascade\Config\Loader\ClassLoader\Resolver;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+use Cascade\Config\Loader\ClassLoader;
+
+/**
+ * Extra options resolver. Set up an option resolver for the passed in params and
+ * apply validation rules if any
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ExtraOptionsResolver
+{
+    /**
+     * Reflection class for which you want to resolve extra options
+     *
+     * @var \ReflectionClass
+     */
+    protected $reflected = null;
+
+    /**
+     * Registry of resolvers
+     *
+     * @var array
+     */
+    private static $resolvers = array();
+
+    /**
+     * Associative array of parameters to resolve against
+     * @var array
+     */
+    protected $params = array();
+
+    /**
+     * Constructor
+     *
+     * @param \ReflectionClass $reflected Reflection class for which you want to resolve
+     * extra options
+     * @param array $params Associative array of extra parameters we want to resolve against
+     */
+    public function __construct(\ReflectionClass $reflected, array $params = array())
+    {
+        $this->reflected = $reflected;
+        $this->setParams($params);
+    }
+
+    /**
+     * Set the parameters we want to resolve against
+     * @param array $params Associative array of extra parameters we want to resolve against
+     */
+    public function setParams(array $params = array())
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * Get the parameters we want to resolve against
+     *
+     * @return array $params Associative array of parameters
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * Returns the reflected object
+     *
+     * @return \ReflectionClass
+     */
+    public function getReflected()
+    {
+        return $this->reflected;
+    }
+
+    /**
+     * Generate a unique hash based on the keys of the extra params
+     *
+     * @param  array $params: array of parameters
+     * @return string unique MD5 hash
+     */
+    public static function generateParamsHashKey($params)
+    {
+        return md5(serialize($params));
+    }
+
+    /**
+     * Configure options for the provided OptionResolver to match extra params requirements
+     *
+     * @param  OptionsResolver $optionsResolver OptionResolver to configure
+     * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
+     * handlers for some of the extra options
+     */
+    protected function configureOptions(OptionsResolver $resolver, ClassLoader $classLoader = null)
+    {
+        foreach ($this->params as $name) {
+            if ($this->reflected->hasMethod($name)) {
+                // There is a method to handle this option
+                $resolver->setDefined($name);
+                continue;
+            }
+            if ($this->reflected->hasProperty($name) &&
+                $this->reflected->getProperty($name)->isPublic()
+            ) {
+                // There is a public member we can set to handle this option
+                $resolver->setDefined($name);
+                continue;
+            }
+
+            // Option that cannot be handled by a regular setter but
+            // requires specific pre-processing and/or handling to be set
+            // e.g. like LogglyHandler::addTag for instance
+            if (!is_null($classLoader) && $classLoader->canHandle($name)) {
+                $resolver->setDefined($name);
+            }
+        }
+    }
+
+    /**
+     * Resolve options against extra params requirements
+     *
+     * @param  array $options Array of option values
+     * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
+     * handlers to resolve the extra options
+     * @return array Array of resolved options
+     */
+    public function resolve($options, ClassLoader $classLoader = null)
+    {
+        $hashKey = self::generateParamsHashKey($this->params);
+
+        // Was configureOptions() executed before for this class?
+        if (!isset(self::$resolvers[$hashKey])) {
+            self::$resolvers[$hashKey] = new OptionsResolver();
+            $this->configureOptions(self::$resolvers[$hashKey], $classLoader);
+        }
+
+        return self::$resolvers[$hashKey]->resolve($options);
+    }
+}

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -1,0 +1,209 @@
+<?php
+namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
+
+use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
+use Cascade\Tests\Fixtures\SampleClass;
+
+/**
+ * Class ConstructorResolverTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Reflection class for which you want to resolve extra options
+     *
+     * @var \ReflectionClass
+     */
+    protected $reflected = null;
+
+    /**
+     * Constructor Resolver
+     *
+     * @var ConstructorResolver
+     */
+    protected $resolver = null;
+
+    /**
+     * Set up function
+     */
+    public function setUp()
+    {
+        $this->class = 'Cascade\Tests\Fixtures\SampleClass';
+        $this->resolver = new ConstructorResolver(new \ReflectionClass($this->class));
+        parent::setUp();
+    }
+
+    /**
+     * Tear down function
+     */
+    public function tearDown()
+    {
+        $this->resolver = null;
+        $this->class = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Return the contructor args of the reflected class
+     *
+     * @return ReflectionParameter[] array of params
+     */
+    protected function getConstructorArgs()
+    {
+        return $this->resolver->getReflected()->getConstructor()->getParameters();
+    }
+
+    /**
+     * Test the resolver contructor
+     */
+    public function testConstructor()
+    {
+        $this->assertEquals($this->class, $this->resolver->getReflected()->getName());
+    }
+
+    /**
+     * Test that constructor args were pulled properly
+     */
+    public function testInitConstructorArgs()
+    {
+        $expectedConstructorArgs = array();
+
+        foreach ($this->getConstructorArgs() as $param) {
+            $expectedConstructorArgs[$param->getName()] = $param;
+        }
+        $this->assertEquals($expectedConstructorArgs, $this->resolver->getConstructorArgs());
+    }
+
+    /**
+     * Test the hashToArgsArray function
+     */
+    public function testHashToArgsArray()
+    {
+        $this->assertEquals(
+            array('someValue', 'hello', 'there'),
+            $this->resolver->hashToArgsArray(
+                array( // Not properly ordered on purpose
+                    'optionalB' => 'there',
+                    'optionalA' => 'hello',
+                    'mandatory' => 'someValue'
+                )
+            )
+        );
+    }
+
+    /**
+     * Data provider for testResolve
+     * @return array of arrays with expected resolved values and options used as input
+     *
+     * The order of the input options does not matter and is somewhat random. The resolution
+     * should reconcile those options and match them up with the contructor param position
+     */
+    public function optionsProvider()
+    {
+        return array(
+            array(
+                array('someValue', 'hello', 'there'), // Expected resolved options
+                array( // Options (order should not matter, part of resolution)
+                    'optionalB' => 'there',
+                    'optionalA' => 'hello',
+                    'mandatory' => 'someValue'
+                )
+            ),
+            array(
+                array('someValue', 'hello', 'BBB'),
+                array(
+                    'mandatory' => 'someValue',
+                    'optionalA' => 'hello'
+                )
+            ),
+            array(
+                array('someValue', 'AAA', 'BBB'),
+                array('mandatory' => 'someValue')
+            )
+        );
+    }
+
+    /**
+     * Test resolving with valid options
+     *
+     * @dataProvider optionsProvider
+     */
+    public function testResolve($expectedResolvedOptions, $options)
+    {
+        $this->assertEquals($expectedResolvedOptions, $this->resolver->resolve($options));
+    }
+
+    /**
+     * Data provider for testResolveWithInvalidOptions
+     * @return array of arrays with expected resolved values and options used as input
+     *
+     * The order of the input options does not matter and is somewhat random. The resolution
+     * should reconcile those options and match them up with the contructor param position
+     */
+    public function missingOptionsProvider()
+    {
+        return array(
+            array(
+                array( // No values
+                ),
+                array( // Missing a mandatory value
+                    'optionalB' => 'BBB'
+                ),
+                array( // Still missing a mandatory value
+                    'optionalB' => 'there',
+                    'optionalA' => 'hello'
+                )
+            )
+        );
+    }
+
+    /**
+     * Test resolving with invalid options
+     *
+     * @dataProvider missingOptionsProvider
+     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testResolveWithMissingOptions($invalidOptions)
+    {
+        $this->resolver->resolve($invalidOptions);
+    }
+
+    /**
+     * Data provider for testResolveWithInvalidOptions
+     * @return array of arrays with expected resolved values and options used as input
+     *
+     * The order of the input options does not matter and is somewhat random. The resolution
+     * should reconcile those options and match them up with the contructor param position
+     */
+    public function invalidOptionsProvider()
+    {
+        return array(
+            array(
+                array('ABC'),
+                array( // All invalid
+                    'someInvalidOptionA' => 'abc',
+                    'someInvalidOptionB' => 'def'
+                ),
+                array( // Some invalid
+                    'optionalB' => 'there',
+                    'optionalA' => 'hello',
+                    'mandatory' => 'dsadsa',
+                    'additionalInvalid' => 'some unknow param'
+                )
+            )
+        );
+    }
+
+    /**
+     * Test resolving with invalid options
+     *
+     * @dataProvider invalidOptionsProvider
+     * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
+     */
+    public function testResolveWithInvalidOptions($invalidOptions)
+    {
+        $this->resolver->resolve($invalidOptions);
+    }
+}

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -1,0 +1,165 @@
+<?php
+namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
+
+use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
+use Cascade\Tests\Fixtures\SampleClass;
+
+/**
+ * Class ExtraOptionsResolverTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Reflection class for which you want to resolve extra options
+     *
+     * @var \ReflectionClass
+     */
+    protected $reflected = null;
+
+    /**
+     * ExtraOptions Resolver
+     *
+     * @var ExtraOptionsResolver
+     */
+    protected $resolver = null;
+
+    /**
+     * Set up function
+     */
+    public function setUp()
+    {
+        $this->class = 'Cascade\Tests\Fixtures\SampleClass';
+        $this->params = array('optionalA', 'optionalB');
+        $this->resolver = new ExtraOptionsResolver(
+            new \ReflectionClass($this->class),
+            $this->params
+        );
+        parent::setUp();
+    }
+
+    /**
+     * Tear down function
+     */
+    public function tearDown()
+    {
+        $this->resolver = null;
+        $this->class = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Test the hsah key generation
+     */
+    public function testGenerateParamsHashKey()
+    {
+        $a = array('optionA', 'optionB', 'optionC');
+        $b = array('optionA', 'optionB', 'optionC');
+
+        $this->assertEquals(
+            ExtraOptionsResolver::generateParamsHashKey($a),
+            ExtraOptionsResolver::generateParamsHashKey($b)
+        );
+    }
+
+    /**
+     * Test the resolver contructor
+     */
+    public function testConstructor()
+    {
+        $this->assertEquals($this->class, $this->resolver->getReflected()->getName());
+        $this->assertEquals($this->params, $this->resolver->getParams());
+    }
+
+    /**
+     * Test resolving with valid options
+     */
+    public function testResolve()
+    {
+        $this->assertEquals(
+            array_combine($this->params, array('hello', 'there')),
+            $this->resolver->resolve(array('optionalB' => 'there', 'optionalA' => 'hello'))
+        );
+
+        // Resolve an empty array (edge case)
+        $this->assertEquals(array(), $this->resolver->resolve(array()));
+    }
+
+    /**
+     * Data provider for testResolveWithInvalidOptions
+     * @return array of arrays with expected resolved values and options used as input
+     *
+     * The order of the input options does not matter and is somewhat random. The resolution
+     */
+    public function optionsProvider()
+    {
+        return array(
+            array(
+                array('optionalA', 'optionalB', 'mandatory'),
+                $this->getMockBuilder('Cascade\Config\Loader\ClassLoader')
+                    ->disableOriginalConstructor()
+                    ->getMock()->method('canHandle')
+                    ->willReturn(true)
+            )
+        );
+    }
+
+    /**
+     * Test resolving with valid options
+     *
+     */
+    public function testResolveWithCustomOptionHandler()
+    {
+        $this->params = array('optionalA', 'optionalB', 'mandatory');
+        $this->resolver = new ExtraOptionsResolver(
+            new \ReflectionClass($this->class),
+            $this->params
+        );
+
+        // Create a stub for the SomeClass class.
+        $stub = $this->getMockBuilder('Cascade\Config\Loader\ClassLoader')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('canHandle')
+            ->willReturn(true);
+
+        // Resolve an empty array (edge case)
+        $this->assertEquals(array('mandatory' => 'abc'), $this->resolver->resolve(array('mandatory' => 'abc'), $stub));
+    }
+
+    /**
+     * Data provider for testResolveWithInvalidOptions
+     * @return array of arrays with expected resolved values and options used as input
+     *
+     * The order of the input options does not matter and is somewhat random. The resolution
+     */
+    public function invalidOptionsProvider()
+    {
+        return array(
+            array(
+                array( // Some invalid
+                    'optionalB' => 'there',
+                    'optionalA' => 'hello',
+                    'additionalInvalid' => 'some unknow param'
+                ),
+                array( // All invalid
+                    'someInvalidOptionA' => 'abc',
+                    'someInvalidOptionB' => 'def'
+                )
+            )
+        );
+    }
+
+    /**
+     * Test resolving with invalid options
+     *
+     * @dataProvider invalidOptionsProvider
+     * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
+     */
+    public function testResolveWithInvalidOptions($invalidOptions)
+    {
+        $this->resolver->resolve($invalidOptions);
+    }
+}


### PR DESCRIPTION
2 resolver classes, they both use a reflected object (see [Reflection](http://php.net/manual/en/book.reflection.php))
 - constructor params: we figure out all constructor params i.e. which are required, which have default values, etc. and configure a [Symfony `OptionsResolver`](https://symfony.com/doc/current/components/options_resolver.html) object
 - extra params: those would be anything that is not identified as a constructor param (from the config file). To consider any of those as valid and defined, we follow those 3 3 simple rules:
  - is there a method matching that params name?
  - is there a public member matching that param name
  - is there a custom handler function set up to handle that param (those handlers would be set up in a loader object passed in)

Those 2 essentially do the same thing:
 1. define valid options from a given class
 2. validate them against passed in params (see the`resolve` method)

Constructor params are _must have_, you need those to instantiate a logger handler (StreamHandler for instance). Extra params is a way to consume more params for the config if needed.
Let's say you want to use a handler but not all the params you want to use can be passed through the constructor [LogglyHandler](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/LogglyHandler.php) for instance. It takes only the token and the level... but let's say you'd like configure tags as well. The way you would typically do it is instantiate your handler first and then call either the `setTag` or `addTag` method.

Cascade allows you to do this automatically by passing `add_tag` as a param so everything is configured in one step

@mortaliorchard @OrCharles

