### PR TITLE
Formatter Loader + Handler Loader

### DIFF
--- a/src/Config/Loader/ClassLoader/FormatterLoader.php
+++ b/src/Config/Loader/ClassLoader/FormatterLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Cascade\Config\Loader\ClassLoader;
+
+use Cascade\Config\Loader\ClassLoader;
+
+/**
+ * Formatter Loader. Loads the Formatter options, validate them and instantiates
+ * a Formatter object (implementing Monolog\Formatter\FormatterInterface) with all
+ * the corresponding options
+ * @see ClassLoader
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class FormatterLoader extends ClassLoader
+{
+    /**
+     * Default formatter class to use if none is provided in the option array
+     */
+    const DEFAULT_CLASS = '\Monolog\Formatter\LineFormatter';
+
+    /**
+     * Constructor
+     * @see ClassLoader::__construct
+     * @see Monolog\Formatter classes for formatter options
+     *
+     * @param array $formatterOptions Formatter options
+     */
+    public function __construct(array $formatterOptions)
+    {
+        parent::__construct($formatterOptions);
+
+        self::initExtraOptionsHandlers();
+    }
+
+    /**
+     * Loads the closures as option handlers. Add handlers to this function if
+     * you want to support additional custom options.
+     *
+     * The syntax is the following:
+     *     array(
+     *         '\Full\Absolute\Namespace\ClassName' => array(
+     *             'myOption' => Closure
+     *         ), ...
+     *     )
+     *
+     * You can use the '*' wildcard if you want to set up an option for all
+     * Formatter classes
+     *
+     * @todo add handlers to handle extra options for all known Monolog formatters
+     */
+    public static function initExtraOptionsHandlers()
+    {
+        self::$extraOptionHandlers = array(
+            '\Monolog\Formatter\LineFormatter' => array(
+                'includeStacktraces' => function ($instance, $include) {
+                    $instance->includeStacktraces($include);
+                }
+            )
+        );
+    }
+}

--- a/src/Config/Loader/ClassLoader/HandlerLoader.php
+++ b/src/Config/Loader/ClassLoader/HandlerLoader.php
@@ -1,0 +1,91 @@
+<?php
+namespace Cascade\Config\Loader\ClassLoader;
+
+use Monolog\Formatter\FormatterInterface;
+
+use Cascade\Config\Loader\ClassLoader;
+
+/**
+ * Handler Loader. Loads the Handler options, validate them and instantiates
+ * a Handler object (implementing Monolog\Handler\HandlerInterface) with all
+ * the corresponding options
+ * @see ClassLoader
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class HandlerLoader extends ClassLoader
+{
+    /**
+     * Default handler class to use if none is provided in the option array
+     */
+    const DEFAULT_CLASS = '\Monolog\Handler\StreamHandler';
+
+    /**
+     * Constructor
+     * @see ClassLoader::__construct
+     * @see Monolog\Handler classes for handler options
+     *
+     * @param array $handlerOptions Handler options
+     * @param Monolog\Formatter\FormatterInterface[] $formatters Array of formatter to pick from
+     */
+    public function __construct(array &$handlerOptions, array $formatters = array())
+    {
+        $this->populateFormatters($handlerOptions, $formatters);
+        parent::__construct($handlerOptions);
+
+        self::initExtraOptionsHandlers();
+    }
+
+    /**
+     * Replace the formatter name in the option array with the corresponding object from the
+     * formatter array passed in if it exists.
+     *
+     * If no formatter is specified in the options, Monolog will use its default formatter for the
+     * handler
+     *
+     * @throws InvalidArgumentException
+     *
+     * @param  array &$handlerOptions Handler options
+     * @param  Monolog\Formatter\FormatterInterface[] $formatters Array of formatter to pick from
+     */
+    private function populateFormatters(array &$handlerOptions, array $formatters)
+    {
+        if (isset($handlerOptions['formatter'])) {
+            if (isset($formatters[$handlerOptions['formatter']])) {
+                $handlerOptions['formatter'] = $formatters[$handlerOptions['formatter']];
+            } else {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Formatter %s not found in the configured formatters',
+                        $handlerOptions['formatter']
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Loads the closures as option handlers. Add handlers to this function if
+     * you want to support additional custom options.
+     *
+     * The syntax is the following:
+     *     array(
+     *         '\Full\Absolute\Namespace\ClassName' => array(
+     *             'myOption' => Closure
+     *         ), ...
+     *     )
+     *
+     * You can use the '*' wildcard if you want to set up an option for all
+     * Handler classes
+     */
+    public static function initExtraOptionsHandlers()
+    {
+        self::$extraOptionHandlers = array(
+            '*' => array(
+                'formatter' => function ($instance, FormatterInterface $formatter) {
+                    $instance->setFormatter($formatter);
+                }
+            )
+        );
+    }
+}

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -1,0 +1,123 @@
+<?php
+namespace Cascade\Tests\Config\Loader\ClassLoader;
+
+use Cascade\Config\Loader\ClassLoader\FormatterLoader;
+
+/**
+ * Class FormatterLoaderTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Set up function
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        new FormatterLoader(array());
+    }
+
+    /**
+     * Tear down function
+     */
+    public function tearDown()
+    {
+        FormatterLoader::$extraOptionHandlers = array();
+        parent::tearDown();
+    }
+
+    /**
+     * Check if the handler exists for a given class and option
+     * Also checks that it a callable and return it
+     *
+     * @param  string $class Class name the handler applies to
+     * @param  string $optionName Option name
+     * @return \Closure Closure
+     */
+    private function getHandler($class, $optionName)
+    {
+        if (isset(FormatterLoader::$extraOptionHandlers[$class][$optionName])) {
+            // Get the closure
+            $closure = FormatterLoader::$extraOptionHandlers[$class][$optionName];
+
+            $this->assertTrue(is_callable($closure));
+
+            return $closure;
+        } else {
+            throw new \Exception(
+                sprintf(
+                    'Handler %s is not defined for class %s',
+                    $optionName,
+                    $class
+                )
+            );
+        }
+    }
+
+    /**
+     * Tests that calling the given Closure will trigger a method call with the given param
+     * in the given class
+     *
+     * @param  string   $class      Class name
+     * @param  string   $methodName Method name
+     * @param  mixed    $methodArg  Parameter passed to the closure
+     * @param  \Closure $closure    Closure to call
+     */
+    private function _testMethodCalledInHandler($class, $methodName, $methodArg, \Closure $closure)
+    {
+        // Setup mock and expectations
+        $mock = $this->getMockBuilder($class)
+            ->setMethods(array($methodName))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method($methodName)
+            ->with($methodArg);
+
+        // Calling the handler
+        $closure($mock, $methodArg);
+    }
+
+
+    /**
+     * Test that handlers exist
+     */
+    public function testHandlersExist()
+    {
+        $this->assertTrue(count(FormatterLoader::$extraOptionHandlers) > 0);
+    }
+
+    /**
+     * Data provider for testHandlers
+     * /!\ Important note: just add values to this array if you need to test a newly added handler
+     * If one of your handlers calls more than one method you can add more than one entries
+     *
+     * @return array of array of args for testHandlers
+     */
+    public function handlerParamsProvider()
+    {
+        return array(
+            array(
+                '\Monolog\Formatter\LineFormatter',  // Class name
+                'includeStacktraces',                // Option name
+                true,                                // Option test value
+                'includeStacktraces'                 // Name of the method called by your handler
+            )
+        );
+    }
+
+    /**
+     * Test the extra option handlers
+     *
+     * @dataProvider handlerParamsProvider
+     */
+    public function testHandlers($class, $optionName, $optionValue, $calledMethodName)
+    {
+        // Test if handler exists and return it
+        $closure = $this->getHandler($class, $optionName);
+
+        $this->_testMethodCalledInHandler($class, $calledMethodName, $optionValue, $closure);
+    }
+}

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -1,0 +1,152 @@
+<?php
+namespace Cascade\Tests\Config\Loader\ClassLoader;
+
+use Monolog\Formatter\LineFormatter;
+
+use Cascade\Config\Loader\ClassLoader\HandlerLoader;
+
+/**
+ * Class HandlerLoaderTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandlerLoader()
+    {
+        $original = $options = array(
+            'class' => '\Monolog\Handler\TestHandler',
+            'level' => 'DEBUG',
+            'formatter' => 'test_formatter'
+        );
+        $formatters = array('test_formatter' => new LineFormatter());
+        $loader = new HandlerLoader($options, $formatters);
+
+        $this->assertNotEquals($original, $options);
+        $this->assertEquals(new LineFormatter(), $options['formatter']);
+    }
+
+    public function testHandlerLoaderWithNoOptions()
+    {
+        $original = $options = array();
+        $loader = new HandlerLoader($options);
+
+        $this->assertEquals($original, $options);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testHandlerLoaderWithInvalidFormatter()
+    {
+        $options = array(
+            'formatter' => 'test_formatter'
+        );
+
+        $formatters = array('test_formatterXYZ' => new LineFormatter());
+        $loader = new HandlerLoader($options, $formatters);
+    }
+
+    /**
+     * Check if the handler exists for a given class and option
+     * Also checks that it a callable and return it
+     *
+     * @param  string $class Class name the handler applies to
+     * @param  string $optionName Option name
+     * @return \Closure Closure
+     */
+    private function getHandler($class, $optionName)
+    {
+        if (isset(HandlerLoader::$extraOptionHandlers[$class][$optionName])) {
+            // Get the closure
+            $closure = HandlerLoader::$extraOptionHandlers[$class][$optionName];
+
+            $this->assertTrue(is_callable($closure));
+
+            return $closure;
+        } else {
+            throw new \Exception(
+                sprintf(
+                    'Custom handler %s is not defined for class %s',
+                    $optionName,
+                    $class
+                )
+            );
+        }
+    }
+
+    /**
+     * Tests that calling the given Closure will trigger a method call with the given param
+     * in the given class
+     *
+     * @param  string   $class      Class name
+     * @param  string   $methodName Method name
+     * @param  mixed    $methodArg  Parameter passed to the closure
+     * @param  \Closure $closure    Closure to call
+     */
+    private function _testMethodCalledInHandler($class, $methodName, $methodArg, \Closure $closure)
+    {
+        // Setup mock and expectations
+        $mock = $this->getMockBuilder($class)
+            ->setMethods(array($methodName))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method($methodName)
+            ->with($methodArg);
+
+        // Calling the handler
+        $closure($mock, $methodArg);
+    }
+
+
+    /**
+     * Test that handlers exist
+     */
+    public function testHandlersExist()
+    {
+        $options = array();
+        new HandlerLoader($options);
+        $this->assertTrue(count(HandlerLoader::$extraOptionHandlers) > 0);
+    }
+
+    /**
+     * Data provider for testHandlers
+     * /!\ Important note:
+     * Just add values to this array if you need to test a newly added handler
+     *
+     * If one of your handlers calls more than one method you can add more than one entries
+     *
+     * @return array of array of args for testHandlers
+     */
+    public function handlerParamsProvider()
+    {
+        return array(
+            array(
+                '*',                    // Class name
+                'formatter',            // Option name
+                new LineFormatter(),    // Option test value
+                'setFormatter'          // Name of the method called by your handler
+            )
+        );
+    }
+
+    /**
+     * Test the extra option handlers
+     *
+     * @dataProvider handlerParamsProvider
+     */
+    public function testHandlers($class, $optionName, $optionValue, $calledMethodName)
+    {
+        $options = array();
+        new HandlerLoader($options);
+        // Test if handler exists and return it
+        $closure = $this->getHandler($class, $optionName);
+
+        if ($class == '*') {
+            $class = '\Monolog\Handler\TestHandler';
+        }
+
+        $this->_testMethodCalledInHandler($class, $calledMethodName, $optionValue, $closure);
+    }
+}

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -1,0 +1,139 @@
+<?php
+namespace Cascade\Tests\Config\Loader;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\Registry;
+
+use Cascade\Config\Loader\ClassLoader;
+use Cascade\Tests\Fixtures\SampleClass;
+
+/**
+ * Class ClassLoaderTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Set up function
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Tear down function
+     */
+    public function tearDown()
+    {
+        ClassLoader::$extraOptionHandlers = array();
+        parent::tearDown();
+    }
+
+    /**
+     * Provides options with and without a class param
+     * @return array of args
+     */
+    public function dataFortestSetClass()
+    {
+        return array(
+            array(
+                array(
+                    'class' => 'Cascade\Tests\Fixtures\SampleClass',
+                    'some_param' => 'abc'
+                ),
+                'Cascade\Tests\Fixtures\SampleClass'
+            ),
+            array(
+                array(
+                    'some_param' => 'abc'
+                ),
+                '\stdClass'
+            )
+        );
+    }
+
+    /**
+     * Testing the setClass method
+     *
+     * @param  array $options array of options
+     * @dataProvider dataFortestSetClass
+     */
+    public function testSetClass($options, $expectedClass)
+    {
+        $loader = new ClassLoader($options);
+
+        $this->assertEquals($expectedClass, $loader->class);
+    }
+
+    public function testOptionsToCamelCase()
+    {
+        $array = array('hello_there' => 'Hello', 'bye_bye' => 'Bye');
+
+        $this->assertEquals(
+            array('helloThere' => 'Hello', 'byeBye' => 'Bye'),
+            ClassLoader::optionsToCamelCase($array)
+        );
+    }
+
+    public function testGetExtraOptionsHandler()
+    {
+        ClassLoader::$extraOptionHandlers = array(
+            '*' => array(
+                'hello' => function ($instance, $value) {
+                    $instance->setHello(strtoupper($value));
+                }
+            ),
+            'Cascade\Tests\Fixtures\SampleClass' => array(
+                'there' => function ($instance, $value) {
+                    $instance->setThere(strtoupper($value).'!!!');
+                }
+            )
+        );
+
+        $loader = new ClassLoader(array());
+        $existingHandler = $loader->getExtraOptionsHandler('hello');
+        $this->assertNotNull($existingHandler);
+        $this->assertTrue(is_callable($existingHandler));
+
+        $this->assertNull($loader->getExtraOptionsHandler('nohandler'));
+    }
+
+    public function testLoad()
+    {
+        $options = array(
+            'class' => 'Cascade\Tests\Fixtures\SampleClass',
+            'mandatory' => 'someValue',
+            'optional_X' => 'testing some stuff',
+            'optional_Y' => 'testing other stuff',
+            'hello' => 'hello',
+            'there' => 'there',
+        );
+
+        ClassLoader::$extraOptionHandlers = array(
+            '*' => array(
+                'hello' => function ($instance, $value) {
+                    $instance->setHello(strtoupper($value));
+                }
+            ),
+            'Cascade\Tests\Fixtures\SampleClass' => array(
+                'there' => function ($instance, $value) {
+                    $instance->setThere(strtoupper($value).'!!!');
+                }
+            )
+        );
+
+        $loader = new ClassLoader($options);
+        $instance = $loader->load();
+
+        $expectedInstance = new SampleClass('someValue');
+        $expectedInstance->optionalX('testing some stuff');
+        $expectedInstance->optionalY = 'testing other stuff';
+        $expectedInstance->setHello('HELLO');
+        $expectedInstance->setThere('THERE!!!');
+
+        $this->assertEquals($expectedInstance, $instance);
+    }
+}


### PR DESCRIPTION
Added the `FormatterLoader`: loads any Monolog Formatter class (implementing the [MonoLog\Formatter\FormatterInterface](https://github.com/Seldaek/monolog/blob/master/src%2FMonolog%2FFormatter%2FFormatterInterface.php))
Added the `HandlerLoader`: loads any Monolog Handler class (implementing the [MonoLog\Handler\HandlerInterface](https://github.com/Seldaek/monolog/blob/master/src%2FMonolog%2FHandler%2FHandlerInterface.php))

They both extend [`ClassLoader`](https://github.com/theorchard/monolog-cascade/blob/master/src/Config/Loader/ClassLoader.php) which was the trouble maker for the previous PR. The reason was a dependency on those extra option handlers in the [`canHandle`](https://github.com/theorchard/monolog-cascade/blob/master/src/Config/Loader/ClassLoader.php#L171) method.
This PR contains the tests for ClassLoader as well.

I need to revisit this at some point cause it makes a double dependency that seems unnecessary. I'd like to get those closures out of here (see `initExtraOptionsHandlers` method).

My favorite reviewers: @mortaliorchard @OrCharles, please review!


Some more info on Monolog:
Monolog Handlers are the handlers attached to you logger. A logger can log to multiple destinations: a simple log file, a stream like stdout or stderr, using an API (Loggly), etc. In order to log into those destination, you need to set up a handler for each of those.
On top of that if you need specific formatter (i.e. formatting each line you log), you need to instantiate a Formatter object and set it in your Handler.
That's why it is kind of tedious to set this manually.
```php
$logger = new \Monolog\Logger();
$f1 = new \Monolog\Formatter\LineFormatter('[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n');
$h1 = new \Monolog\Handler\LogglyHandler($myToken, $logLevel);
$h2 = new \Monolog\Handler\StreamHandler('php://stdout');
$h1->setFormatter($f1);
$h2->setFormatter($f1);
$logger->pushHandler($h1);
$logger->pushHandler($h2);

// And then finally
$logger->info('Writing with my logger');
$logger->error('uh oh, something happened');
```
I used the same formatter for the 2 handlers but this gets much longer if you have multiple handlers with multiple formatter.

The formatter loader takes a set of options for the formatter, typically the `formatter` section of you yaml file
```yaml
formatters:
    spaced:
        class: Monolog\Formatter\LineFormatter
        format: "%datetime% %channel%.%level_name%  %message%\n"
        include_stacktraces: true
```
And it instantiate the corresponding Formatter object with the provided options.

The Handler loader does the same thing for the provided Handlers
```yaml
handlers:
    console:
        class: Monolog\Handler\StreamHandler
        level: DEBUG
        formatter: spaced
        stream: php://stdout
    info_file_handler:
        class: Monolog\Handler\StreamHandler
        level: INFO
        formatter: dashed
        stream: ./example_info.log
```
You'll notice that handlers can reference previously defined formatter(s). So, Cascade will load formatters first and then will instantiate the Handlers.

I hope this helps