### PR TITLE
Add LoggerLoader + Cascade Config class + Monologger

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,167 @@
+<?php
+namespace Cascade;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Registry;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+
+use Cascade\Config\ConfigLoader;
+use Cascade\Config\Loader\ClassLoader\FormatterLoader;
+use Cascade\Config\Loader\ClassLoader\HandlerLoader;
+use Cascade\Config\Loader\ClassLoader\LoggerLoader;
+
+/**
+ * Config class that takes a config resource (file, JSON, Yaml, etc.) and configure Loggers with
+ * all the required options (Formatters, Handlers, etc.)
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class Config
+{
+    /**
+     * Input from user. This is either a file path, a string or an array
+     * @var string | array
+     */
+    protected $input = null;
+
+    /**
+     * Array of logger configuration options: (logger attributes, formatters, handlers, etc.)
+     * @var array
+     */
+    protected $options = array();
+
+    /**
+     * Array of Formatter objects
+     * @var FormatterInterface[]
+     */
+    protected $formatters = array();
+
+    /**
+     * Array of Handler objects
+     * @var HandlerInterface[]
+     */
+    protected $handlers = array();
+
+    /**
+     * Array of Processor objects
+     * @var callable[]
+     */
+    protected $processors = array();
+
+    /**
+     * Array of logger objects
+     * @var Monolog\Logger[]
+     */
+    protected $loggers = array();
+
+    /**
+     * Config loader
+     * @var ConfigLoader
+     */
+    protected $loader = null;
+
+    /**
+     * Instantiate a Config object
+     *
+     * @param string | array $input user input
+     * @param ConfigLoader $loader Config loader object
+     */
+    public function __construct($input, ConfigLoader $loader)
+    {
+        $this->input = $input;
+        $this->loader = $loader;
+    }
+
+    /**
+     * Load config options into the options array using the injected loader
+     */
+    public function load()
+    {
+        $this->options = $this->loader->load($this->input);
+    }
+
+    /**
+     * Configure and register Logger(s) according to the options passed in
+     */
+    public function configure()
+    {
+        if (!isset($this->options['disable_existing_loggers'])) {
+            // We disable any existing loggers by default
+            $this->options['disable_existing_loggers'] = true;
+        }
+
+        if ($this->options['disable_existing_loggers']) {
+            Registry::clear();
+        }
+
+        if (isset($this->options['formatters'])) {
+            $this->configureFormatters($this->options['formatters']);
+        }
+
+        if (isset($this->options['handlers'])) {
+            $this->configureHandlers($this->options['handlers']);
+        }
+
+        if (isset($this->options['processors'])) {
+            $this->configureProcessors($this->options['processors']);
+        }
+
+        if (isset($this->options['loggers'])) {
+            $this->configureLoggers($this->options['loggers']);
+        } else {
+            throw new \RuntimeException(
+                'Cannot configure loggers. No logger configuration options provided.'
+            );
+        }
+    }
+
+    /**
+     * Configure the formatters
+     * @param  array $formatters array of formatter options
+     */
+    protected function configureFormatters(array $formatters = array())
+    {
+        foreach ($formatters as $formatterId => $formatterOptions) {
+            $formatterLoader = new FormatterLoader($formatterOptions);
+            $this->formatters[$formatterId] = $formatterLoader->load();
+        }
+    }
+
+    /**
+     * Configure the handlers
+     * @param  array $handlers array of handler options
+     */
+    protected function configureHandlers(array $handlers)
+    {
+        foreach ($handlers as $handlerId => $handlerOptions) {
+            $handlerLoader = new HandlerLoader($handlerOptions, $this->formatters);
+            $this->handlers[$handlerId] = $handlerLoader->load();
+        }
+    }
+
+    /**
+     * Configure the processors
+     *
+     * @todo Implement adding processors for both Loggers and Handlers
+     * @param  array $processors array of processor options
+     */
+    protected function configureProcessors(array $processors)
+    {
+        // To implement
+    }
+
+    /**
+     * Configure the loggers
+     *
+     * @param  array $loggers array of logger options
+     */
+    protected function configureLoggers(array $loggers)
+    {
+        foreach ($loggers as $loggerName => $loggerOptions) {
+            $loggerLoader = new LoggerLoader($loggerName, $loggerOptions, $this->handlers);
+            $this->loggers[$loggerName] = $loggerLoader->load();
+        }
+    }
+}

--- a/src/Config/Loader/ClassLoader/LoggerLoader.php
+++ b/src/Config/Loader/ClassLoader/LoggerLoader.php
@@ -1,0 +1,173 @@
+<?php
+namespace Cascade\Config\Loader\ClassLoader;
+
+use Cascade\MonoLogger;
+use Cascade\Config\Loader\ClassLoader;
+
+/**
+ * Logger Loader. Instantiate a Logger and set passed in handlers and processors if any
+ * @see ClassLoader
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class LoggerLoader
+{
+    /**
+     * Array of options
+     * @var array
+     */
+    protected $loggerOptions = array();
+
+    /**
+     * Array of handlers
+     * @var Monolog\Handler\HandlerInterface[]
+     */
+    protected $handlers = array();
+
+    /**
+     * Array of processors
+     * @var callable[]
+     */
+    protected $processors = array();
+
+    /**
+     * Logger
+     * @var Monolog\Logger
+     */
+    protected $logger = null;
+
+    /**
+     * Constructor
+     *
+     * @param string $loggerName Name of the logger
+     * @param array  $loggerOptions Array of logger options
+     * @param Monolog\Handler\HandlerInterface[] $handlers Array of Monolog handlers
+     * @param callable[] $processors Array of processors
+     */
+    public function __construct(
+        $loggerName,
+        array $loggerOptions = array(),
+        array $handlers = array(),
+        array $processors = array()
+    ) {
+        $this->loggerOptions = $loggerOptions;
+        $this->handlers = $handlers;
+        $this->processors = $processors;
+
+        // This instanciates a Logger object and set it to the Registry
+        $this->logger = MonoLogger::getLogger($loggerName);
+    }
+
+    /**
+     * Resolve handlers for that Logger (if any provided) against an array of previously set
+     * up handlers. Returns an array of valid handlers.
+     *
+     * @throws InvalidArgumentException if a requested handler is not available in $handlers
+     *
+     * @param  array $loggerOptions array of logger options
+     * @param  Monolog\Handler\HandlerInterface[] $handlers Available Handlers to resolve against
+     * @return Monolog\Handler\HandlerInterface[] Array of Monolog handlers
+     */
+    public function resolveHandlers(array $loggerOptions, array $handlers)
+    {
+        $handlerArray = array();
+
+        if (isset($loggerOptions['handlers'])) {
+            // If handlers have been specified and, they do exist in the provided handlers array
+            // We return an array of handler objects
+            foreach ($loggerOptions['handlers'] as $handlerId) {
+                if (isset($handlers[$handlerId])) {
+                    $handlerArray[] = $handlers[$handlerId];
+                } else {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            'Cannot add handler "%s" to the logger "%s". Handler not found.',
+                            $handlerId,
+                            $this->logger->getName()
+                        )
+                    );
+                }
+            }
+        }
+
+        // If nothing is set there is nothing to resolve, Handlers will be Monolog's default
+
+        return $handlerArray;
+    }
+
+    /**
+     * Resolve processors for that Logger (if any provided) against an array of previously set
+     * up processors.
+     *
+     * @throws InvalidArgumentException if a requested processor is not available in $processors
+     *
+     * @param  array $loggerOptions array of logger options
+     * @param  callable[] $processors Available Processors to resolve against
+     * @return callable[] Array of Monolog processors
+     */
+    public function resolveProcessors(array $loggerOptions, $processors)
+    {
+        $processorArray = array();
+
+        if (isset($loggerOptions['processors'])) {
+            // If processors have been specified and, they do exist in the provided processors array
+            // We return an array of processor objects
+            foreach ($loggerOptions['processors'] as $processorId) {
+                if (isset($processors[$processorId])) {
+                    $processorArray[] = $processors[$processorId];
+                } else {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            'Cannot add processor "%s" to the logger "%s". Processor not found.',
+                            $processorId,
+                            $this->logger->getName()
+                        )
+                    );
+                }
+            }
+        }
+
+        // If nothing is set there is nothing to resolve, Processors will be Monolog's default
+
+        return $processorArray;
+    }
+
+    /**
+     * Add handlers to the Logger
+     *
+     * @param Monolog\Handler\HandlerInterface[] Array of Monolog handlers
+     */
+    private function addHandlers(array $handlers)
+    {
+        // We need to reverse the array because Monolog "pushes" handlers to top of the stack
+        foreach (array_reverse($handlers) as $handler) {
+            $this->logger->pushHandler($handler);
+        }
+    }
+
+    /**
+     * Add processors to the Logger
+     *
+     * @param callable[] Array of Monolog processors
+     */
+    private function addProcessors(array $processors)
+    {
+        // We need to reverse the array because Monolog "pushes" processors to top of the stack
+        foreach (array_reverse($processors) as $processor) {
+            $this->logger->pushProcessor($processor);
+        }
+    }
+
+    /**
+     * Return the instantiated Logger object based on its name
+     *
+     * @return Monolog\Logger Logger object
+     */
+    public function load()
+    {
+        $this->addHandlers($this->resolveHandlers($this->loggerOptions, $this->handlers));
+        $this->addProcessors($this->resolveProcessors($this->loggerOptions, $this->processors));
+
+        return $this->logger;
+    }
+}

--- a/src/MonoLogger.php
+++ b/src/MonoLogger.php
@@ -1,0 +1,85 @@
+<?php
+namespace Cascade;
+
+use Monolog\Logger;
+use Monolog\Registry;
+
+use Cascade\Config;
+use Cascade\Config\ConfigLoader;
+
+/**
+ * Module class that manages Monolog Logger object
+ * @see Monolog\Logger
+ *
+ * @todo remove inheritance. There is no need to extend Logger
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class MonoLogger extends Logger
+{
+    /**
+     * Config class that holds options for all registered loggers
+     * This is optional, you can set up your loggers programmatically
+     * @var Cascade\Config
+     */
+    protected static $config = null;
+
+    /**
+     * Instantiate a new MonoLogger object
+     *
+     * @see Monolog\Logger::__construct
+     *
+     * @param string $name The logging channel
+     * @param HandlerInterface[] $handlers Optional stack of handlers,
+     * the first one in the array is called first, etc.
+     * @param callable[] $processors Optional array of processors
+     *
+     * @throws \InvalidArgumentException: if no name is given
+     */
+    public function __construct(
+        $name,
+        array $handlers = array(),
+        array $processors = array()
+    ) {
+
+        if (empty($name)) {
+            throw new \InvalidArgumentException('Logger name is required.');
+        }
+
+        parent::__construct($name, $handlers, $processors);
+        Registry::addLogger($this);
+    }
+
+    /**
+     * Get a Logger instance by name. Creates a new one if a Logger with the
+     * provided name does not exist
+     *
+     * @param  string $name Name of the requested Logger instance
+     * @return Monolog\Logger Requested instance of Logger or new instance
+     */
+    public static function getLogger($name)
+    {
+        return Registry::hasLogger($name) ? Registry::getInstance($name) : new MonoLogger($name);
+    }
+
+    /**
+     * Return the config options
+     *
+     * @return array array with configuration options
+     */
+    public static function getConfig()
+    {
+        return self::$config;
+    }
+
+    /**
+     * Load configuration options from a file or a string
+     *
+     * @param string $resource path to config file or string or array
+     */
+    public static function fileConfig($resource)
+    {
+        self::$config = new Config($resource, new ConfigLoader());
+        self::$config->load();
+        self::$config->configure();
+    }
+}

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -1,0 +1,136 @@
+<?php
+namespace Cascade\Tests\Config\Loader\ClassLoader;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\Registry;
+
+use Cascade\Config\Loader\ClassLoader\LoggerLoader;
+
+/**
+ * Class LoggerLoaderTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tear down function
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        Registry::clear();
+    }
+
+    public function testConstructor()
+    {
+        $loader = new LoggerLoader('testLogger');
+
+        $this->assertTrue(Registry::hasLogger('testLogger'));
+    }
+
+    public function testResolveHandlers()
+    {
+        $options = array(
+            'handlers' => array('test_handler_1', 'test_handler_2')
+        );
+        $handlers = array(
+            'test_handler_1' => new TestHandler(),
+            'test_handler_2' => new TestHandler()
+        );
+        $loader = new LoggerLoader('testLogger', $options, $handlers);
+
+        $this->assertEquals(
+            array_values($handlers),
+            $loader->resolveHandlers($options, $handlers)
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testResolveHandlersWithMismatch()
+    {
+        $options = array(
+            'handlers' => array('unexisting_handler', 'test_handler_2')
+        );
+        $handlers = array(
+            'test_handler_1' => new TestHandler(),
+            'test_handler_2' => new TestHandler()
+        );
+        $loader = new LoggerLoader('testLogger', $options, $handlers);
+
+        // This should throw an InvalidArgumentException
+        $loader->resolveHandlers($options, $handlers);
+    }
+
+    public function testResolveProcessors()
+    {
+        $dummyClosure = function () {
+            // Empty function
+        };
+        $options = array(
+            'processors' => array('test_processor_1', 'test_processor_2')
+        );
+        $processors = array(
+            'test_processor_1' => $dummyClosure,
+            'test_processor_2' => $dummyClosure
+        );
+
+        $loader = new LoggerLoader('testLogger', $options, array(), $processors);
+
+        $this->assertEquals(
+            array_values($processors),
+            $loader->resolveProcessors($options, $processors)
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testResolveProcessorsWithMismatch()
+    {
+        $dummyClosure = function () {
+            // Empty function
+        };
+        $options = array(
+            'processors' => array('unexisting_processor', 'test_processor_2')
+        );
+        $processors = array(
+            'test_processor_1' => $dummyClosure,
+            'test_processor_2' => $dummyClosure
+        );
+
+        $loader = new LoggerLoader('testLogger', $options, array(), $processors);
+
+        // This should throw an InvalidArgumentException
+        $loader->resolveProcessors($options, $processors);
+    }
+
+    public function testLoad()
+    {
+        $options = array(
+            'handlers' => array('test_handler_1', 'test_handler_2'),
+            'processors' => array('test_processor_1', 'test_processor_2')
+        );
+        $handlers = array(
+            'test_handler_1' => new TestHandler(),
+            'test_handler_2' => new TestHandler()
+        );
+        $dummyClosure = function () {
+            // Empty function
+        };
+        $processors = array(
+            'test_processor_1' => $dummyClosure,
+            'test_processor_2' => $dummyClosure
+        );
+
+        $loader = new LoggerLoader('testLogger', $options, $handlers, $processors);
+        $logger = $loader->load();
+
+        $this->assertTrue($logger instanceof Logger);
+        $this->assertEquals(array_values($handlers), $logger->getHandlers());
+        $this->assertEquals(array_values($processors), $logger->getProcessors());
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Cascade\Tests;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\Registry;
+
+use Cascade\Config;
+use Cascade\Tests\Fixtures;
+
+/**
+ * Class ConfigTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class ConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Testing contructor and load functions
+     */
+    public function testLoad()
+    {
+        $mock = $this->getMockBuilder('Cascade\Config\ConfigLoader')
+            ->disableOriginalConstructor()
+            ->setMethods(array('load'))
+            ->getMock();
+
+        $array = Fixtures::getSamplePhpArray();
+
+        $mock->expects($this->once())
+            ->method('load')
+            ->willReturn($array);
+
+        $config = new Config(array(''), $mock);
+        $config->load();
+    }
+
+    public function testConfigure()
+    {
+        $options = Fixtures::getPhpArrayConfig();
+
+        // Mocking the ConfigLoader with the load method
+        $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
+            ->disableOriginalConstructor()
+            ->setMethods(array('load'))
+            ->getMock();
+
+        $configLoader->method('load')->willReturn($options);
+
+        // Mocking the config object and set expectations for the configure methods
+        $config = $this->getMockBuilder('Cascade\Config')
+            ->setConstructorArgs(array($options, $configLoader))
+            ->setMethods(array(
+                    'configureFormatters',
+                    'configureHandlers',
+                    'configureProcessors',
+                    'configureLoggers'
+                ))
+            ->getMock();
+
+        $config->expects($this->once())->method('configureFormatters');
+        $config->expects($this->once())->method('configureHandlers');
+        $config->expects($this->once())->method('configureProcessors');
+        $config->expects($this->once())->method('configureLoggers');
+
+        $config->load();
+        $config->configure();
+    }
+
+    /**
+     * Test configure throwing an exception due to missing 'loggers' key
+     * @expectedException \RuntimeException
+     */
+    public function testConfigureWithNoLoggers()
+    {
+        $options = array();
+
+        // Mocking the ConfigLoader with the load method
+        $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
+            ->disableOriginalConstructor()
+            ->setMethods(array('load'))
+            ->getMock();
+
+        $configLoader->method('load')->willReturn($options);
+
+        // Mocking the config object
+        $config = $this->getMockBuilder('Cascade\Config')
+            ->setConstructorArgs(array($options, $configLoader))
+            ->setMethods(null)
+            ->getMock();
+
+        $config->load();
+
+        // This should trigger an exception because there is no 'loggers' key in
+        // the options passed in
+        $config->configure();
+    }
+
+    public function testLoggersConfigured()
+    {
+        $options = Fixtures::getPhpArrayConfig();
+
+        // Mocking the ConfigLoader with the load method
+        $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
+            ->disableOriginalConstructor()
+            ->setMethods(array('load'))
+            ->getMock();
+
+        $configLoader->method('load')->willReturn($options);
+
+        $config = new Config($options, $configLoader);
+
+        $config->load();
+        $config->configure();
+
+        $this->assertTrue(Registry::hasLogger('my_logger'));
+    }
+}

--- a/tests/MonoLoggerTest.php
+++ b/tests/MonoLoggerTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Cascade\Tests;
+
+use Monolog\Logger;
+use Monolog\Registry;
+
+use Cascade\MonoLogger;
+use Cascade\Tests\Fixtures;
+
+/**
+ * Class MonoLoggerTest
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class MonoLoggerTest extends \PHPUnit_Framework_TestCase
+{
+    public function teardown()
+    {
+        Registry::clear();
+        parent::teardown();
+    }
+
+    public function testRegistry()
+    {
+        $logger = MonoLogger::getLogger('test');
+
+        $this->assertTrue($logger instanceof Logger);
+        $this->assertEquals('test', $logger->getName());
+        $this->assertTrue(Registry::hasLogger('test'));
+
+        // We should get the logger from the registry this time
+        $logger2 = MonoLogger::getLogger('test');
+        $this->assertSame($logger, $logger2);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRegistryWithInvalidName()
+    {
+        $logger = MonoLogger::getLogger(null);
+    }
+
+    public function testFileConfig()
+    {
+        $options = Fixtures::getPhpArrayConfig();
+        MonoLogger::fileConfig($options);
+        $this->assertInstanceOf('Cascade\Config', MonoLogger::getConfig());
+    }
+}


### PR DESCRIPTION
I had to group those 3 cause `MonoLogger` uses the config class and the `LoggerLoader` instantiates the `Logger` object using `MonoLogger::getLogger()`

So, here is what this does:
 - `LoggerLoader`: like the other loaders it reads the `loggers` config section and instantiates a `\Monolog\Logger` object and adds the corresponding handlers to it

 ```yaml
 loggers:
     some_logger:
         handlers: [console, info_file_handler]
 ```

 - `Config`: it is the main Cascade config class. It coordinates the sequence of loading the different components and pass thing around like passing Formatters to the `HandlerLoader` and passing Handlers to the `LoggerLoader`
 - `MonoLogger` is the interface to trigger the config loading (using the `fileConfig` method). So, it is calling the config class to load a resource, then loaders kick in and take care of all the complex stuff (resolving params, etc). Additionally `Monologger` populates the `\Monolog\Registry` so we can access our configured loggers from anywhere using `Monologger::getLogger` (might write a alias to shorten that up, any idea? `L::og('some_logger')`?? `L::get('some_logger')`? `MonoLogger::get('some_logger')`)?

 ```php
 // easy as pie...
 MonoLogger::fileConfig('path/to/yaml_file.yml'); 
 MonoLogger::getLogger('loggerA')->info('Well, that works!');
 MonoLogger::getLogger('loggerB')->error('Maybe not...');
 ```

@mortaliorchard @OrCharles 

That's all folks! (in term of code...)