### PR TITLE
Adding more php versions for Travis CI. Allow failure for php > 5.6 to begin with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,28 @@ language: php
 
 sudo: false
 
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7
+    - hhvm
+
 matrix:
-    include:
-        - php: 5.3
-        - php: 5.4
-        # - php: 5.5
-        # - php: 5.6
-        # - php: 7
-        # - php: hhvm
+    allow_failures:
+        # allow failure for Php >= 5.6
+        - php: 7
+        - php: hhvm
     fast_finish: true
 
 install:
   composer install --prefer-source
 
+# before_script:
+#     - mkdir -p build/logs
+
 script: ./vendor/bin/phpunit
+
+# after_script:
+#     - php vendor/bin/coveralls


### PR DESCRIPTION
Introducing more php versions allowing failures for now for php > 5.6.
