### PR TITLE
Added 'tags' option alias to set Loggly tags as opposed to using 'set…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/options-resolver": "~2.7.0",
         "symfony/serializer": "~2.7.0",
         "symfony/yaml": "~2.7.0",
-        "monolog/monolog": "~1.13"
+        "monolog/monolog": "~1.14"
     },
     "autoload": {
         "psr-4": {

--- a/src/Config/Loader/ClassLoader/HandlerLoader.php
+++ b/src/Config/Loader/ClassLoader/HandlerLoader.php
@@ -94,6 +94,11 @@ class HandlerLoader extends ClassLoader
                 'formatter' => function ($instance, FormatterInterface $formatter) {
                     $instance->setFormatter($formatter);
                 }
+            ),
+            'Monolog\Handler\LogglyHandler' => array(
+                'tags' => function ($instance, $tags) {
+                    $instance->setTag($tags);
+                }
             )
         );
     }

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -97,6 +97,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     {
         // Setup mock and expectations
         $mock = $this->getMockBuilder($class)
+            ->disableOriginalConstructor()
             ->setMethods(array($methodName))
             ->getMock();
 
@@ -136,6 +137,12 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
                 'formatter',            // Option name
                 new LineFormatter(),    // Option test value
                 'setFormatter'          // Name of the method called by your handler
+            ),
+            array(
+                'Monolog\Handler\LogglyHandler',    // Class name
+                'tags',                             // Option name
+                array('some_tag'),                  // Option test value
+                'setTag'                            // Name of the method called by your handler
             )
         );
     }
@@ -153,7 +160,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
         $closure = $this->getHandler($class, $optionName);
 
         if ($class == '*') {
-            $class = '\Monolog\Handler\TestHandler';
+            $class = 'Monolog\Handler\TestHandler';
         }
 
         $this->doTestMethodCalledInHandler($class, $calledMethodName, $optionValue, $closure);


### PR DESCRIPTION
…_tag'

@mortaliorchard 

we can now just simply write:
```yaml
handlers:
    console:
        class: Monolog\Handler\StreamHandler
        level: DEBUG
        stream: php://stdout
    loggly:
        class: Monolog\Handler\LogglyHandler
        token: xxxx-xxxxx-xxxx-xxxx-xxxxxxx
        level: INFO
        tags: [cascade, waterfall]

loggers:
    my_logger:
        handlers: [console, loggly]

```
to configure Loggly handler with the desired tags.

/!\ Merging this is pending next Monolog's release as there is a bug in the Loggly handler.
[Fix](https://github.com/Seldaek/monolog/commit/5bdba762dac6df5124e7195b8fa17ce85a21e718) has been provided but it is still on master.