### PR TITLE
Fix the fixture files to account for processors. Should get back the …

### DIFF
--- a/tests/Fixtures/fixture_config.json
+++ b/tests/Fixtures/fixture_config.json
@@ -32,6 +32,11 @@
       "encoding": "utf8"
     }
   },
+  "processors": {
+    "tag_processor": {
+      "class": "Monolog\\Processor\\TagProcessor"
+    }
+  },
   "loggers": {
     "my_logger": {
       "level": "ERROR",

--- a/tests/Fixtures/fixture_config.php
+++ b/tests/Fixtures/fixture_config.php
@@ -44,7 +44,11 @@ $fixtureArray = array(
             'formatter' => 'spaced'
         )
     ),
-    'processors' => array(),
+    'processors' => array(
+        'tag_processor' => array(
+            'class' => 'Monolog\Processor\TagProcessor'
+        )
+    ),
     'loggers' => array(
         'my_logger' => array(
             'handlers' => array('console', 'info_file_handler')

--- a/tests/Fixtures/fixture_config.yml
+++ b/tests/Fixtures/fixture_config.yml
@@ -10,6 +10,10 @@ formatters:
     dashed:
         format: "%datetime%-%channel%.%level_name% - %message%\n"
 
+processors:
+    tag_processor:
+        class: Monolog\Processor\TagProcessor
+
 handlers:
     console:
         class: Monolog\Handler\StreamHandler


### PR DESCRIPTION
…coverage to 100%

@OrCharles A contributor kindly added support for Logger processors. See https://github.com/theorchard/monolog-cascade/pull/25
This makes sure the tests are set up properly to actually test a entire config parsing that includes a processor. This would fix the code coverage decrease.

Note that I picked TagProcessor class for the fixture but this is not relevant for the test. I just needed some Processor. Processors are tested in Monolog. Here, we just test that the Processor has been pushed to the Logger instance when parsing the config file.