### PR TITLE
Add support for handlers where constructor params are objects to fix #30

### DIFF
--- a/examples/dependency_config.yml
+++ b/examples/dependency_config.yml
@@ -1,0 +1,22 @@
+---
+version: 1
+
+disable_existing_loggers: false
+
+handlers:
+    sentry:
+        class: Monolog\Handler\RavenHandler
+        level: DEBUG
+        raven_client:
+            class: Raven_Client
+            options_or_dsn: https://something:dummy@getsentry.com/1
+    redis:
+        class: Monolog\Handler\RedisHandler
+        level: DEBUG
+        key: cascade
+        redis:
+            class: Redis
+            connect: ['127.0.0.1', 6379]
+loggers:
+    dependency:
+        handlers: [sentry, redis]

--- a/examples/dependency_logger.php
+++ b/examples/dependency_logger.php
@@ -1,0 +1,13 @@
+<?php
+require_once(realpath(__DIR__.'/../vendor/autoload.php'));
+
+use Cascade\Cascade;
+
+// For these to work you will need php-redis and raven/raven
+
+// You will want to update this file with a valid dsn
+$loggerConfigFile = realpath(__DIR__.'/dependency_config.yml');
+
+Cascade::fileConfig($loggerConfigFile);
+Cascade::getLogger('dependency')->info('Well, that works!');
+Cascade::getLogger('dependency')->error('Maybe not...');

--- a/src/Config/Loader/ClassLoader.php
+++ b/src/Config/Loader/ClassLoader.php
@@ -99,6 +99,25 @@ class ClassLoader
     }
 
     /**
+     * Recursively loads objects into any of the rawOptions that represent
+     * a class
+     *
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    protected function loadChildClasses()
+    {
+        foreach ($this->rawOptions as &$option) {
+            if (is_array($option)
+                && array_key_exists('class', $option)
+                && class_exists($option['class'])
+            ) {
+                $classLoader = new ClassLoader($option);
+                $option = $classLoader->load();
+            }
+        }
+    }
+
+    /**
      * Return option values indexed by name using camelCased keys
      *
      * @param  array  $options array of options
@@ -163,6 +182,8 @@ class ClassLoader
      */
     public function load()
     {
+        $this->loadChildClasses();
+
         list($constructorResolvedOptions, $extraResolvedOptions) = $this->resolveOptions();
         $instance = $this->reflected->newInstanceArgs($constructorResolvedOptions);
 

--- a/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
@@ -11,6 +11,7 @@
 namespace Cascade\Config\Loader\ClassLoader\Resolver;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * Constructor Resolver. Pull args from the contructor and set up an option
@@ -55,15 +56,19 @@ class ConstructorResolver
     /**
      * Fetches constructor args (array of ReflectionParameter) from the reflected class
      * and set them as an associative array
+     *
+     * Convert the parameter names to camelCase for classes that have contructor
+     * params defined in snake_case for consistency with the options
      */
     public function initConstructorArgs()
     {
         $constructor = $this->reflected->getConstructor();
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
 
         if (!is_null($constructor)) {
             // Index parameters by their names
             foreach ($constructor->getParameters() as $param) {
-                $this->constructorArgs[$param->getName()] = $param;
+                $this->constructorArgs[$nameConverter->denormalize($param->getName())] = $param;
             }
         }
     }

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -16,6 +16,7 @@ use Monolog\Registry;
 
 use Cascade\Config\Loader\ClassLoader;
 use Cascade\Tests\Fixtures\SampleClass;
+use Cascade\Tests\Fixtures\DependentClass;
 
 /**
  * Class ClassLoaderTest
@@ -142,6 +143,31 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
         $expectedInstance->optionalY = 'testing other stuff';
         $expectedInstance->setHello('HELLO');
         $expectedInstance->setThere('THERE!!!');
+
+        $this->assertEquals($expectedInstance, $instance);
+    }
+
+    /**
+     * Test a nested class to load
+     *
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    public function testLoadDependency()
+    {
+        $options = array(
+            'class' => 'Cascade\Tests\Fixtures\DependentClass',
+            'dependency' => [
+                'class' => 'Cascade\Tests\Fixtures\SampleClass',
+                'mandatory' => 'someValue',
+            ]
+        );
+
+        $loader = new ClassLoader($options);
+        $instance = $loader->load();
+
+        $expectedInstance = new DependentClass(
+            new SampleClass('someValue')
+        );
 
         $this->assertEquals($expectedInstance, $instance);
     }

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -156,10 +156,10 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $options = array(
             'class' => 'Cascade\Tests\Fixtures\DependentClass',
-            'dependency' => [
+            'dependency' => array(
                 'class' => 'Cascade\Tests\Fixtures\SampleClass',
                 'mandatory' => 'someValue',
-            ]
+            )
         );
 
         $loader = new ClassLoader($options);

--- a/tests/Fixtures/DependentClass.php
+++ b/tests/Fixtures/DependentClass.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of the Monolog Cascade package.
+ *
+ * (c) Raphael Antonmattei <rantonmattei@theorchard.com>
+ * (c) The Orchard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cascade\Tests\Fixtures;
+
+/**
+ * Class SampleClass
+ *
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ */
+class DependentClass
+{
+    /**
+     * An object dependency
+     * @var Cascade\Tests\Fixtures\SampleClass
+     */
+    private $dependency;
+
+    /**
+     * Constructor
+     *
+     * @param mixed $mandatory Some mandatory param
+     * @param string $optionalA Some optional param
+     */
+    public function __construct(
+        SampleClass $dependency
+    ) {
+        $this->setDependency($dependency);
+    }
+
+    /**
+     * Set the object dependency
+     *
+     * @param Cascade\Tests\Fixtures\SampleClass $dependency Some value
+     */
+    public function setDependency($dependency)
+    {
+        $this->dependency = $dependency;
+    }
+}

--- a/tests/Fixtures/SampleClass.php
+++ b/tests/Fixtures/SampleClass.php
@@ -69,7 +69,8 @@ class SampleClass
     public function __construct(
         $mandatory,
         $optionalA = 'AAA',
-        $optionalB = 'BBB'
+        $optionalB = 'BBB',
+        $optional_snake = 'snake'
     ) {
         $this->setMandatory($mandatory);
     }


### PR DESCRIPTION
A stab at fixing #30 by making the ClassLoader recursive.

As a side effect it is necessary to convert constructor params to camelCase to support non PSR-2 compliant constructors (basically Raven_Client). This irritatingly adds an extra dependency into `Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver` which I'm not very proud of.

A couple of examples have been added for Raven and Redis in `examples/dependency_config.yml`.

Let me know what you think.
