### PR TITLE
Support for processors per handler.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -107,12 +107,12 @@ class Config
             $this->configureFormatters($this->options['formatters']);
         }
 
-        if (isset($this->options['handlers'])) {
-            $this->configureHandlers($this->options['handlers']);
-        }
-
         if (isset($this->options['processors'])) {
             $this->configureProcessors($this->options['processors']);
+        }
+
+        if (isset($this->options['handlers'])) {
+            $this->configureHandlers($this->options['handlers']);
         }
 
         if (isset($this->options['loggers'])) {
@@ -143,7 +143,7 @@ class Config
     protected function configureHandlers(array $handlers)
     {
         foreach ($handlers as $handlerId => $handlerOptions) {
-            $handlerLoader = new HandlerLoader($handlerOptions, $this->formatters);
+            $handlerLoader = new HandlerLoader($handlerOptions, $this->formatters, $this->processors);
             $this->handlers[$handlerId] = $handlerLoader->load();
         }
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -61,15 +61,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs(array($options, $configLoader))
             ->setMethods(array(
                     'configureFormatters',
-                    'configureHandlers',
                     'configureProcessors',
+                    'configureHandlers',
                     'configureLoggers'
                 ))
             ->getMock();
 
         $config->expects($this->once())->method('configureFormatters');
-        $config->expects($this->once())->method('configureHandlers');
         $config->expects($this->once())->method('configureProcessors');
+        $config->expects($this->once())->method('configureHandlers');
         $config->expects($this->once())->method('configureLoggers');
 
         $config->load();


### PR DESCRIPTION
@rantonmattei @mortaliorchard Please review.

This enables users to specify processors on the handler level (which gets run after logger-level specified processors are run). Elaborating on the README's sample usage for configuration yml file, for `git_processor` would be:

```
formatters:
    dashed:
        class: Monolog\Formatter\LineFormatter
        format: "%datetime%-%channel%.%level_name% - %message%\n"
handlers:
    console:
        class: Monolog\Handler\StreamHandler
        level: DEBUG
        formatter: dashed
        stream: php://stdout
    info_file_handler:
        class: Monolog\Handler\StreamHandler
        level: INFO
        formatter: dashed
        stream: ./example_info.log
        processors: [git_processor]
processors:
    web_processor:
        class: Monolog\Processor\WebProcessor
   git_processor:
       class: Monolog\Processor\GitProcessor
loggers:
    myLogger:
        handlers: [console, info_file_handler]
        processors: [web_processor]
```


