### PR TITLE
Add support for configurable wrapped handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ If some parameters are not present in the constructor, they will be treated as e
     - `class` (optional): classname of the handler you would like to use
     - `formatter` (optional): formatter identifier that you have defined
     - `processors` (optional): array of processor identifiers that you have defined
+    - `handlers` (optional): array of handler identifiers that you have defined
+    - `handler` (optional): single handler identifier that you have defined
 
     Other parameters will be interpreted as constructor parameters for that Handler class and passed in when the handler object is instantiated by the Cascade config loader.<br />
     If some parameters are not present in the constructor, they will be interpreted as extra parameters and Cascade will try to interpret them should they match any custom handler functions that are able to use them. (see [Extra Parameters](#user-content-extra-parameters-other-than-constructors) section below)

--- a/src/Config.php
+++ b/src/Config.php
@@ -143,7 +143,7 @@ class Config
     protected function configureHandlers(array $handlers)
     {
         foreach ($handlers as $handlerId => $handlerOptions) {
-            $handlerLoader = new HandlerLoader($handlerOptions, $this->formatters, $this->processors);
+            $handlerLoader = new HandlerLoader($handlerOptions, $this->formatters, $this->processors, $this->handlers);
             $this->handlers[$handlerId] = $handlerLoader->load();
         }
     }

--- a/src/Config/Loader/ClassLoader/HandlerLoader.php
+++ b/src/Config/Loader/ClassLoader/HandlerLoader.php
@@ -37,14 +37,17 @@ class HandlerLoader extends ClassLoader
      * @param array $handlerOptions Handler options
      * @param Monolog\Formatter\FormatterInterface[] $formatters Array of formatter to pick from
      * @param callable[] $processors Array of processors to pick from
+     * @param callable[] $handlers Array of handlers to pick from
      */
     public function __construct(
         array &$handlerOptions,
         array $formatters = array(),
-        array $processors = array()
+        array $processors = array(),
+        array $handlers = array()
     ) {
         $this->populateFormatters($handlerOptions, $formatters);
         $this->populateProcessors($handlerOptions, $processors);
+        $this->populateHandlers($handlerOptions, $handlers);
         parent::__construct($handlerOptions);
 
         self::initExtraOptionsHandlers();
@@ -106,6 +109,52 @@ class HandlerLoader extends ClassLoader
             }
 
             $handlerOptions['processors'] = $processorArray;
+        }
+    }
+
+     /**
+     * Replace the handler or handlers in the option array with the corresponding callable(s) from the
+     * array of loaded and callable handlers, if they exist.
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @param  array &$handlerOptions Handler options
+     * @param  callable[] $handlers Array of handlers to pick from
+     */
+    private function populateHandlers(array &$handlerOptions, array $handlers)
+    {
+        $handlerArray = array();
+
+        if (isset($handlerOptions['handlers'])) {
+            foreach ($handlerOptions['handlers'] as $handlerId) {
+                if (isset($handlers[$handlerId])) {
+                    $handlerArray[] = $handlers[$handlerId];
+                } else {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            'Cannot add handler "%s" to the handler. Handler not found.',
+                            $handlerId
+                        )
+                    );
+                }
+            }
+
+            $handlerOptions['handlers'] = $handlerArray;
+        }
+
+        if (isset($handlerOptions['handler'])) {
+            $handlerId = $handlerOptions['handler'];
+
+            if (isset($handlers[$handlerId])) {
+                $handlerOptions['handler'] = $handlers[$handlerId];
+            } else {
+                 throw new \InvalidArgumentException(
+                     sprintf(
+                         'Cannot add handler "%s" to the handler. Handler not found.',
+                         $handlerId
+                     )
+                 );
+            }
         }
     }
 

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -218,4 +218,32 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
         $closure = $this->getHandler('*', 'processors');
         $closure($mockHandler, $processorsArray);
     }
+
+    public function testReplacesHandlerNamesInOptionsArrayWithLoadedCallable()
+    {
+        $options = [
+            'handlers' => [
+                'foo',
+                'bar',
+            ],
+            'handler' => 'baz'
+        ];
+        $handlers = [
+            'foo' => function () {
+                return 'foo';
+            },
+            'bar' => function () {
+                return 'bar';
+            },
+            'baz' => function () {
+                return 'baz';
+            },
+        ];
+
+        $loader = new HandlerLoader($options, [], [], $handlers);
+
+        $this->assertSame($handlers['foo'], $options['handlers'][0]);
+        $this->assertSame($handlers['bar'], $options['handlers'][1]);
+        $this->assertSame($handlers['baz'], $options['handler']);
+    }
 }

--- a/tests/Fixtures/fixture_config.php
+++ b/tests/Fixtures/fixture_config.php
@@ -40,7 +40,20 @@ $fixtureArray = array(
             'level' => 'ERROR',
             'stream' => './demo_error.log',
             'formatter' => 'spaced'
-        )
+        ),
+
+        'group_handler' => array(
+            'class' => 'Monolog\Handler\GroupHandler',
+            'handlers' => [
+                'console',
+                'info_file_handler',
+            ],
+        ),
+
+        'fingers_crossed_handler' => array(
+            'class' => 'Monolog\Handler\FingersCrossedHandler',
+            'handler' => 'group_handler',
+        ),
     ),
     'processors' => array(
         'tag_processor' => array(


### PR DESCRIPTION
This pull request adds support for using Monolog's [Special / Wrapped Handlers](https://github.com/Seldaek/monolog/blob/master/doc/02-handlers-formatters-processors.md#wrappers--special-handlers) with configuration alone. Let's take, for example, the `GroupHandler` and `FingersCrossedHandler`.

`GroupHandler` lets you group several other handlers together, and `FingersCrossedHandler` accumulates log messages until severity exceeds a particular log level. In my case, I want to record all of my messages once the `CRITICAL` threshold is reached, and I want them to go to a file and to Slack. After this PR, I can do something like this:

```yaml
handlers:
    file:
        class: Monolog\Handler\StreamHandler
        level: DEBUG
        stream: /path/to/file.log
    slack:
        class: Monolog\Handler\SlackHandler
        ... various slack config goes here ...
    group:
        class: Monolog\Handler\GroupHandler
        handlers: [file, slack]
    fingers_crossed:
        class: Monolog\Handler\FingersCrossedHandler
        handler: group
loggers:
    myLogger:
        handlers: [fingers_crossed]
```

It will replace the `[file, slack]` array in `handlers.group.handlers` with the actual `file` and `slack` handlers, and the `group` entry in `handlers.fingers_crossed.handler` with the actual `group` handler.

PR includes tests, and I don't see any BC issues stemming from this.