### PR TITLE
Add support for loading PHP array config from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,57 @@ loggers:
         processors: [web_processor]
 ```
 
+Here is a sample PHP config file:
+```php
+<?php
+
+return array(
+    'version' => 1,
+
+    'formatters' => array(
+        'spaced' => array(
+            'format' => "%datetime% %channel%.%level_name%  %message%\n",
+            'include_stacktraces' => true
+        ),
+        'dashed' => array(
+            'format' => "%datetime%-%channel%.%level_name% - %message%\n"
+        ),
+    ),
+    'handlers' => array(
+        'console' => array(
+            'class' => 'Monolog\Handler\StreamHandler',
+            'level' => 'DEBUG',
+            'formatter' => 'spaced',
+            'stream' => 'php://stdout'
+        ),
+
+        'info_file_handler' => array(
+            'class' => 'Monolog\Handler\StreamHandler',
+            'level' => 'INFO',
+            'formatter' => 'dashed',
+            'stream' => './demo_info.log'
+        ),
+
+        'error_file_handler' => array(
+            'class' => 'Monolog\Handler\StreamHandler',
+            'level' => 'ERROR',
+            'stream' => './demo_error.log',
+            'formatter' => 'spaced'
+        )
+    ),
+    'processors' => array(
+        'tag_processor' => array(
+            'class' => 'Monolog\Processor\TagProcessor'
+        )
+    ),
+    'loggers' => array(
+        'my_logger' => array(
+            'handlers' => array('console', 'info_file_handler')
+        )
+    )
+);
+```
+
 More information on how the Cascade config parser loads and reads the parameters:
 
 Only the `loggers` key is required. If `formatters` and/or `handlers` are ommitted, Monolog's default will be used. `processors` is optional and if ommitted, no processors will be used. (See the "Optional Keys" section further below).

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 
 use Cascade\Config\Loader\PhpArray as ArrayLoader;
+use Cascade\Config\Loader\FileLoader\PhpArray as ArrayFromFileLoader;
 use Cascade\Config\Loader\FileLoader\Json as JsonLoader;
 use Cascade\Config\Loader\FileLoader\Yaml as YamlLoader;
 
@@ -44,6 +45,7 @@ class ConfigLoader extends DelegatingLoader
             // Do not change that order, it does matter as the resolver returns the first loader
             // that meets the requirements of the "supports" method for each of those loaders
             new ArrayLoader(),
+            new ArrayFromFileLoader($this->locator),
             new JsonLoader($this->locator),
             new YamlLoader($this->locator)
         ));

--- a/src/Config/Loader/FileLoader/PhpArray.php
+++ b/src/Config/Loader/FileLoader/PhpArray.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the Monolog Cascade package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cascade\Config\Loader\FileLoader;
+
+/**
+ * PhpArray loader class. Loads a file that returns a PHP array.
+ *
+ * @see FileLoaderAbstract
+ */
+class PhpArray extends FileLoaderAbstract
+{
+    /**
+     * Valid file extensions for this loader
+     *
+     * @var array
+     */
+    public static $validExtensions = array('php');
+
+    /**
+     * Load a PHP file
+     *
+     * @param  string $resource  File path to a PHP file that returns an array
+     * @param  string|null $type This is not used
+     * @return array             array containing data from the PHP file
+     */
+    public function load($resource, $type = null)
+    {
+        $config = include $resource;
+
+        if (!is_array($config)) {
+            throw new \InvalidArgumentException(
+                sprintf('The file "%s" did not return a valid PHP array when included', $resource)
+            );
+        }
+
+        return $config;
+    }
+
+    /**
+     * Return whether or not the resource passed in is supported by this loader
+     * /!\ This does not verify that the php file returns a valid array. An exception
+     * will be thrown when it is loaded if that is not the case.
+     *
+     * @param  string $resource filepath
+     * @param  string $type     not used
+     * @return boolean          whether or not the passed in resource is supported by this loader
+     */
+    public function supports($resource, $type = null)
+    {
+        return $this->isFile($resource) && $this->validateExtension($resource);
+    }
+}

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -51,7 +51,7 @@ class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         $configLoaders = $this->loader->getResolver()->getLoaders();
-        $this->assertCount(3, $configLoaders);
+        $this->assertCount(4, $configLoaders);
 
         // Checking the order of thr loaders
         $this->assertInstanceOf(
@@ -59,12 +59,16 @@ class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
             $configLoaders[0]
         );
         $this->assertInstanceOf(
-            'Cascade\Config\Loader\FileLoader\Json',
+            'Cascade\Config\Loader\FileLoader\PhpArray',
             $configLoaders[1]
         );
         $this->assertInstanceOf(
-            'Cascade\Config\Loader\FileLoader\Yaml',
+            'Cascade\Config\Loader\FileLoader\Json',
             $configLoaders[2]
+        );
+        $this->assertInstanceOf(
+            'Cascade\Config\Loader\FileLoader\Yaml',
+            $configLoaders[3]
         );
     }
 

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the Monolog Cascade package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cascade\Tests\Config\Loader\FileLoader;
+
+use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
+use Cascade\Tests\Fixtures;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * Class PhpArrayTest
+ */
+class PhpArrayTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ArrayLoader
+     */
+    protected $loader;
+
+    protected function setUp()
+    {
+        $this->loader = new ArrayLoader(new FileLocator());
+    }
+
+    protected function tearDown()
+    {
+        $this->loader = null;
+    }
+
+    public function testSupportsPhpFile()
+    {
+        $this->assertTrue($this->loader->supports(__DIR__ . '/../../../Fixtures/fixture_config.php'));
+    }
+
+    public function testDoesNotSupportNonPhpFiles()
+    {
+        $this->assertFalse($this->loader->supports('foo'));
+        $this->assertFalse($this->loader->supports(__DIR__ . '/../../../Fixtures/fixture_config.json'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWhenLoadingFileIfDoesNotReturnValidPhpArray()
+    {
+        $this->loader->load(__DIR__ . '/../../../Fixtures/fixture_invalid_config.php');
+    }
+
+    public function testLoadsPhpArrayConfigFromFile()
+    {
+        $this->assertSame(
+            include __DIR__ . '/../../../Fixtures/fixture_config.php',
+            $this->loader->load(__DIR__ . '/../../../Fixtures/fixture_config.php')
+        );
+    }
+}

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -108,9 +108,7 @@ class Fixtures
      */
     public static function getPhpArrayConfig()
     {
-        require self::fixtureDir().'/fixture_config.php';
-
-        return $fixtureArray;
+        return require self::fixtureDir().'/fixture_config.php';
     }
 
     /**

--- a/tests/Fixtures/fixture_config.php
+++ b/tests/Fixtures/fixture_config.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-$fixtureArray = array(
+return array(
     'version' => 1,
 
     'formatters' => array(

--- a/tests/Fixtures/fixture_invalid_config.php
+++ b/tests/Fixtures/fixture_invalid_config.php
@@ -1,0 +1,3 @@
+<?php
+
+// This is just a PHP file that _doesn't_ return an array. Used in Cascade\Config\Loader\FileLoader\PhpArrayTest


### PR DESCRIPTION
This addresses #48 and makes it easier to load configs from file as PHP arrays for folks who already use arrays in their application config, rather than yaml or json.