### PR TITLE
Fixed min reqs that were bumped up by mistake. Symfony packages >= 2.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": ">=5.3.9",
-        "symfony/config": "~2.8",
-        "symfony/options-resolver": "~2.8",
-        "symfony/serializer": "~2.8",
-        "symfony/yaml": "~2.8",
-        "monolog/monolog": "~1.17"
+        "symfony/config": "~2.7",
+        "symfony/options-resolver": "~2.7",
+        "symfony/serializer": "~2.7",
+        "symfony/yaml": "~2.7",
+        "monolog/monolog": "~1.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
…7.0 are required. Monolog min version brought down to 1.13.x which is when the Registry class was updated. (Required for Cascade)