### PR TITLE
Removed unnecessary symfony version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": ">=5.3.9",
-        "symfony/config": "~2.7|~3.0|~3.1",
-        "symfony/options-resolver": "~2.7|~3.0|~3.1",
-        "symfony/serializer": "~2.7|~3.0|~3.1",
-        "symfony/yaml": "~2.7|~3.0|~3.1",
+        "symfony/config": "~2.7|~3.0",
+        "symfony/options-resolver": "~2.7|~3.0",
+        "symfony/serializer": "~2.7|~3.0",
+        "symfony/yaml": "~2.7|~3.0",
         "monolog/monolog": "~1.13"
     },
     "autoload": {


### PR DESCRIPTION
`~3.0` covers `~3.1` as well because it is equivalent to `>=3.0.0.0-dev <4.0.0.0-dev`

FYI @adeptofvoltron 