### PR TITLE
Added aliases for Cascade::fileConfig plus a bunch of minor fixes

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -10,16 +10,16 @@
  */
 namespace Cascade;
 
+use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Registry;
 
-use Cascade\Config;
 use Cascade\Config\ConfigLoader;
 
 /**
  * Module class that manages Monolog Logger object
- * @see Monolog\Logger
- * @see Monolog\Registry
+ * @see Logger
+ * @see Registry
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
@@ -34,12 +34,12 @@ class Cascade
 
     /**
      * Create a new Logger object and push it to the registry
-     * @see Monolog\Logger::__construct
+     * @see Logger::__construct
      *
      * @throws \InvalidArgumentException if no name is given
      *
      * @param string $name The logging channel
-     * @param Monolog\Handler\HandlerInterface[] $handlers Optional stack of handlers, the first
+     * @param HandlerInterface[] $handlers Optional stack of handlers, the first
      * one in the array is called first, etc.
      * @param callable[] $processors Optional array of processors
      *
@@ -90,7 +90,7 @@ class Cascade
     /**
      * Return the config options
      *
-     * @return array Array with configuration options
+     * @return Config Array with configuration options
      */
     public static function getConfig()
     {
@@ -98,14 +98,36 @@ class Cascade
     }
 
     /**
-     * Load configuration options from a file or a string
+     * Load configuration options from a file, a JSON or Yaml string or an array.
      *
-     * @param string $resource Path to config file or string or array
+     * @param string|array $resource Path to config file or configuration as string or array
      */
     public static function fileConfig($resource)
     {
         self::$config = new Config($resource, new ConfigLoader());
         self::$config->load();
         self::$config->configure();
+    }
+
+    /**
+     * Load configuration options from a JSON or Yaml string. Alias of fileConfig.
+     * @see fileConfig
+     *
+     * @param string $configString Configuration in string form
+     */
+    public static function loadConfigFromString($configString)
+    {
+        self::fileConfig($configString);
+    }
+
+    /**
+     * Load configuration options from an array. Alias of fileConfig.
+     * @see fileConfig
+     *
+     * @param array $configArray Configuration in array form
+     */
+    public static function loadConfigFromArray($configArray)
+    {
+        self::fileConfig($configArray);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,7 +10,7 @@
  */
 namespace Cascade;
 
-use Monolog\Registry;
+use Monolog;
 
 use Cascade\Config\ConfigLoader;
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
@@ -99,7 +99,7 @@ class Config
         }
 
         if ($this->options['disable_existing_loggers']) {
-            Registry::clear();
+            Monolog\Registry::clear();
         }
 
         if (isset($this->options['formatters'])) {

--- a/src/Config/Loader/ClassLoader/FormatterLoader.php
+++ b/src/Config/Loader/ClassLoader/FormatterLoader.php
@@ -10,7 +10,7 @@
  */
 namespace Cascade\Config\Loader\ClassLoader;
 
-use Monolog\Formatter\LineFormatter;
+use Monolog;
 
 use Cascade\Config\Loader\ClassLoader;
 
@@ -63,7 +63,7 @@ class FormatterLoader extends ClassLoader
     {
         self::$extraOptionHandlers = array(
             'Monolog\Formatter\LineFormatter' => array(
-                'includeStacktraces' => function (LineFormatter $instance, $include) {
+                'includeStacktraces' => function (Monolog\Formatter\LineFormatter $instance, $include) {
                     $instance->includeStacktraces($include);
                 }
             )

--- a/src/Config/Loader/ClassLoader/LoggerLoader.php
+++ b/src/Config/Loader/ClassLoader/LoggerLoader.php
@@ -11,7 +11,8 @@
 namespace Cascade\Config\Loader\ClassLoader;
 
 use Cascade\Cascade;
-use Cascade\Config\Loader\ClassLoader;
+
+use Monolog;
 
 /**
  * Logger Loader. Instantiate a Logger and set passed in handlers and processors if any

--- a/src/Config/Loader/ClassLoader/ProcessorLoader.php
+++ b/src/Config/Loader/ClassLoader/ProcessorLoader.php
@@ -12,6 +12,8 @@ namespace Cascade\Config\Loader\ClassLoader;
 
 use Cascade\Config\Loader\ClassLoader;
 
+use Monolog;
+
 /**
  * Processor Loader. Loads the Processor options, validate them and instantiates
  * a Processor object (implementing Monolog\Processor\ProcessorInterface) with all

--- a/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
@@ -98,7 +98,7 @@ class ExtraOptionsResolver
     /**
      * Configure options for the provided OptionResolver to match extra params requirements
      *
-     * @param  OptionsResolver $optionsResolver OptionResolver to configure
+     * @param  OptionsResolver $resolver OptionResolver to configure
      * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
      * handlers for some of the extra options
      */

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -14,7 +14,6 @@ use Monolog\Logger;
 use Monolog\Registry;
 
 use Cascade\Cascade;
-use Cascade\Tests\Fixtures;
 
 /**
  * Class CascadeTest
@@ -49,17 +48,38 @@ class CascadeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testRegistryWithInvalidName()
     {
-        $logger = Cascade::getLogger(null);
+        Cascade::getLogger(null);
     }
 
     public function testFileConfig()
     {
+        $filePath = Fixtures::getPhpArrayConfigFile();
+        Cascade::fileConfig($filePath);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromArray()
+    {
         $options = Fixtures::getPhpArrayConfig();
-        Cascade::fileConfig($options);
+        Cascade::loadConfigFromArray($options);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromStringWithJson()
+    {
+        $jsonConfig = Fixtures::getJsonConfig();
+        Cascade::loadConfigFromString($jsonConfig);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromStringWithYaml()
+    {
+        $yamlConfig = Fixtures::getYamlConfig();
+        Cascade::loadConfigFromString($yamlConfig);
         $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
     }
 }

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -43,8 +43,8 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
-     *
      * @return \Closure Closure
+     * @throws \Exception
      */
     private function getHandler($class, $optionName)
     {

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -54,7 +54,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidFormatter()
     {
@@ -67,7 +67,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidProcessor()
     {
@@ -84,7 +84,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidHandler()
     {
@@ -102,7 +102,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidHandlers()
     {
@@ -128,8 +128,8 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
-     *
      * @return \Closure Closure
+     * @throws \Exception
      */
     private function getHandler($class, $optionName)
     {

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -57,7 +57,7 @@ class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testResolveHandlersWithMismatch()
     {
@@ -96,7 +96,7 @@ class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testResolveProcessorsWithMismatch()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -13,6 +13,8 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
+use Symfony;
+
 /**
  * Class ConstructorResolverTest
  *
@@ -55,7 +57,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Return the contructor args of the reflected class
      *
-     * @return ReflectionParameter[] array of params
+     * @return \ReflectionParameter[] array of params
      */
     protected function getConstructorArgs()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -12,6 +12,8 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
 
+use Symfony;
+
 /**
  * Class ExtraOptionsResolverTest
  *

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -95,7 +95,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
      * Test validating the extension
      *
      * @param boolean $expected Expected boolean value
-     * @param string filepath Filepath to validate
+     * @param string $filepath Filepath to validate
      * @dataProvider extensionsDataProvider
      */
     public function testValidateExtension($expected, $filepath)
@@ -152,7 +152,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * Test loading an invalid file
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testloadFileFromInvalidFile()
     {

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -43,6 +43,16 @@ class Fixtures
     }
 
     /**
+     * Return a config as Yaml
+     *
+     * @return string Yaml config
+     */
+    public static function getYamlConfig()
+    {
+        return file_get_contents(self::fixtureDir().'/fixture_config.yml');
+    }
+
+    /**
      * Return the fixture sample Yaml file
      *
      * @return string Path to a sample yaml file
@@ -74,6 +84,16 @@ class Fixtures
     public static function getJsonConfigFile()
     {
         return self::fixtureDir().'/fixture_config.json';
+    }
+
+    /**
+     * Return a config as JSON
+     *
+     * @return string JSON config
+     */
+    public static function getJsonConfig()
+    {
+        return file_get_contents(self::fixtureDir().'/fixture_config.json');
     }
 
     /**
@@ -109,6 +129,16 @@ class Fixtures
     public static function getSampleString()
     {
         return " some string with new \n\n lines and white spaces \n\n";
+    }
+
+    /**
+     * Return the fixture PHP array config file
+     *
+     * @return string Path to PHP array config file
+     */
+    public static function getPhpArrayConfigFile()
+    {
+        return self::fixtureDir().'/fixture_config.php';
     }
 
     /**

--- a/tests/Fixtures/SampleClass.php
+++ b/tests/Fixtures/SampleClass.php
@@ -65,6 +65,7 @@ class SampleClass
      * @param mixed $mandatory Some mandatory param
      * @param string $optionalA Some optional param
      * @param string $optionalB Some other optional param
+     * @param string $optional_snake Some optional snake param
      */
     public function __construct(
         $mandatory,


### PR DESCRIPTION
Now I finally came through to add that missing array param for the fileConfig method myself, as we discussed in issue #70.
While I was at it I also added two aliases for Cascade::fileConfig. I know, it's not perfect, but maybe it will do. Feel free to suggest any changes and I will implement them! :-)
I also fixed a lot of minor bugs, mainly in the phpdocs, maybe I've overdone a bit.. But most of the work did PhpStorm by itself to be completely honest.

This is also my first PR on Github so I hope I didn't made any bigger mistakes.