### PR TITLE
Make tests compatible PHPUnit 4.8 and 5.7

### DIFF
--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -20,7 +20,7 @@ use Cascade\Cascade;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class CascadeTest extends \PHPUnit_Framework_TestCase
+class CascadeTest extends TestCase
 {
     public function teardown()
     {

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\ConfigLoader;
 use Cascade\Tests\Fixtures;
 
@@ -18,7 +19,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
+class ConfigLoaderTest extends TestCase
 {
     /**
      * Loader to test against

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
 
 /**
@@ -17,7 +18,7 @@ use Cascade\Config\Loader\ClassLoader\FormatterLoader;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
+class FormatterLoaderTest extends TestCase
 {
     /**
      * Set up function

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Monolog\Formatter\LineFormatter;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\ClassLoader\HandlerLoader;
 
 /**
@@ -19,7 +20,7 @@ use Cascade\Config\Loader\ClassLoader\HandlerLoader;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
+class HandlerLoaderTest extends TestCase
 {
     public function testHandlerLoader()
     {

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -14,6 +14,7 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Monolog\Registry;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\ClassLoader\LoggerLoader;
 
 /**
@@ -21,7 +22,7 @@ use Cascade\Config\Loader\ClassLoader\LoggerLoader;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
+class LoggerLoaderTest extends TestCase
 {
     /**
      * Tear down function

--- a/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Monolog\Processor\WebProcessor;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
 
 /**
@@ -19,7 +20,7 @@ use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
  *
  * @author Kate Burdon <kburdon@tableau.com>
  */
-class ProcessorLoaderTest extends \PHPUnit_Framework_TestCase
+class ProcessorLoaderTest extends TestCase
 {
     public function testProcessorLoader()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
+use Cascade\Tests\TestCase;
 
 use Symfony;
 
@@ -20,7 +21,7 @@ use Symfony;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
+class ConstructorResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -11,6 +11,7 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
+use Cascade\Tests\TestCase;
 
 use Symfony;
 
@@ -19,7 +20,7 @@ use Symfony;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
+class ExtraOptionsResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\ClassLoader;
 use Cascade\Tests\Fixtures\DependentClass;
 use Cascade\Tests\Fixtures\SampleClass;
@@ -20,7 +21,7 @@ use Cascade\Tests\Fixtures\SampleClass;
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  * @author Dom Morgan <dom@d3r.com>
  */
-class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassLoaderTest extends TestCase
 {
     /**
      * Set up function

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use Cascade\Tests\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\FileLocatorInterface;
 use org\bovigo\vfs\vfsStream;
@@ -21,7 +22,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
+class FileLoaderAbstractTest extends TestCase
 {
     /**
      * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use Cascade\Tests\TestCase;
 use Cascade\Tests\Fixtures;
 
 /**
@@ -17,7 +18,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     /**
      * JSON loader mock builder

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -9,12 +9,13 @@ namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Symfony\Component\Config\FileLocator;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
 
 /**
  * Class PhpArrayTest
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * @var ArrayLoader

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
+use Cascade\Tests\TestCase;
 use Cascade\Tests\Fixtures;
 
 /**
@@ -19,7 +20,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class YamlTest extends \PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     /**
      * Yaml loader mock builder

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -10,6 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader;
 
+use Cascade\Tests\TestCase;
 use Cascade\Config\Loader\PhpArray as ArrayLoader;
 use Cascade\Tests\Fixtures;
 
@@ -18,7 +19,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * Array loader object

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -20,7 +20,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * Testing contructor and load functions

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,4 +4,24 @@ namespace Cascade\Tests;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
+    public function getMock($originalClassName, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false, $proxyTarget = null)
+    {
+        $phpUnitVersion = \PHPUnit_Runner_Version::id();
+
+        if (version_compare($phpUnitVersion, '5.7.0', 'lt')) {
+            return parent::getMock(
+                $originalClassName,
+                $methods,
+                $arguments,
+                $mockClassName,
+                $callOriginalConstructor,
+                $callOriginalClone,
+                $callAutoload,
+                $cloneArguments,
+                $callOriginalMethods,
+                $proxyTarget
+            );
+        }
+        return $this->createMock($originalClassName);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Cascade\Tests;
+
+abstract class TestCase extends \PHPUnit_Framework_TestCase
+{
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -9,7 +9,7 @@ use Cascade\Util;
  *
  * @author Deniz Dogan <deniz@dogan.se>
  */
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     public function testSnakeToCamelCase()
     {


### PR DESCRIPTION
Hello,

Because the PHPUnit version 4.8 is no longer supported, we could think to raise dependencies higher or just make the code compatible.

I'll propose you the second option, with two commits : 

- decouple test case from PHPUnit framework itself
- make the mock getter compatible both versions

Awaiting your feedback.

Currently code without my PR, with PHP 5.6.31 and PHPUnit 5.7 output such results : 

```
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.

....................................................WWWWWWWWWWWWW 65 / 97 ( 67%)
WWWWWWWWW....WWWWWWWWW..........                                  97 / 97 (100%)

Time: 9.79 seconds, Memory: 18.50MB

There were 31 warnings:

1) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testReadFrom
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testLoadFileFromString
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testValidateExtension with data set #0 (true, 'hello/world.test')
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

4) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testValidateExtension with data set #1 (true, 'hello/world.php')
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

5) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testValidateExtension with data set #2 (false, 'hello/world.jpeg')
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

6) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testValidateExtension with data set #3 (false, 'hello/world')
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

7) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testValidateExtension with data set #4 (false, '')
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

8) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testGetSectionOf with data set #0 (array(array('AA', 'AB'), array('BA', 'BB')), 'b', array('BA', 'BB'))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

9) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testGetSectionOf with data set #1 (array('A', 'B'), 'c', array('A', 'B'))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

10) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testGetSectionOf with data set #2 (array('A', 'B'), '', array('A', 'B'))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

11) Cascade\Tests\Config\Loader\FileLoader\FileLoaderAbstractTest::testloadFileFromInvalidFile
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

12) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testLoad
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

13) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #0 (array())
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

14) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #1 (true)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

15) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #2 (123)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

16) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #3 (123.456)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

17) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #4 (null)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

18) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #5 (stdClass Object ())
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

19) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithInvalidResource with data set #6 (Closure Object (...))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

20) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithJsonString
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

21) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithJsonFile
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

22) Cascade\Tests\Config\Loader\FileLoader\JsonTest::testSupportsWithNonJsonString
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

23) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testLoad
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

24) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #0 (array())
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

25) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #1 (true)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

26) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #2 (123)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

27) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #3 (123.456)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

28) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #4 (null)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

29) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithInvalidResource with data set #5 (stdClass Object ())
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

30) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithYamlString
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

31) Cascade\Tests\Config\Loader\FileLoader\YamlTest::testSupportsWithYamlFile
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

WARNINGS!
Tests: 97, Assertions: 139, Warnings: 31.


Code Coverage Report:
  2017-10-23 18:14:17

 Summary:
  Classes: 100.00% (16/16)
  Methods: 100.00% (70/70)
  Lines:   100.00% (381/381)

\Cascade::Cascade
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 18/ 18)
\Cascade::Config
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 46/ 46)
\Cascade::Util
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  4/  4)
\Cascade\Config::ConfigLoader
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% ( 10/ 10)
\Cascade\Config\Loader::ClassLoader
  Methods: 100.00% ( 9/ 9)   Lines: 100.00% ( 73/ 73)
\Cascade\Config\Loader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader::FormatterLoader
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  6/  6)
\Cascade\Config\Loader\ClassLoader::HandlerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 69/ 69)
\Cascade\Config\Loader\ClassLoader::LoggerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 48/ 48)
\Cascade\Config\Loader\ClassLoader::ProcessorLoader
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader\Resolver::ConstructorResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 33/ 33)
\Cascade\Config\Loader\ClassLoader\Resolver::ExtraOptionsResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 28/ 28)
\Cascade\Config\Loader\FileLoader::FileLoaderAbstract
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 13/ 13)
\Cascade\Config\Loader\FileLoader::Json
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  9/  9)
\Cascade\Config\Loader\FileLoader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  7/  7)
\Cascade\Config\Loader\FileLoader::Yaml
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  6/  6)
```

With my PR, with PHP 5.6.31 and PHPUnit 4.8 give 

```
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

................................................................. 65 / 97 ( 67%)
................................

Time: 23.97 seconds, Memory: 10.50MB

OK (97 tests, 139 assertions)


Code Coverage Report:
  2017-10-23 19:09:27

 Summary:
  Classes: 100.00% (16/16)
  Methods: 100.00% (70/70)
  Lines:   100.00% (381/381)

\Cascade::Cascade
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 18/ 18)
\Cascade::Config
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 46/ 46)
\Cascade::Util
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  4/  4)
\Cascade\Config::ConfigLoader
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% ( 10/ 10)
\Cascade\Config\Loader::ClassLoader
  Methods: 100.00% ( 9/ 9)   Lines: 100.00% ( 73/ 73)
\Cascade\Config\Loader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader::FormatterLoader
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  6/  6)
\Cascade\Config\Loader\ClassLoader::HandlerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 69/ 69)
\Cascade\Config\Loader\ClassLoader::LoggerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 48/ 48)
\Cascade\Config\Loader\ClassLoader::ProcessorLoader
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader\Resolver::ConstructorResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 33/ 33)
\Cascade\Config\Loader\ClassLoader\Resolver::ExtraOptionsResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 28/ 28)
\Cascade\Config\Loader\FileLoader::FileLoaderAbstract
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 13/ 13)
\Cascade\Config\Loader\FileLoader::Json
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  9/  9)
\Cascade\Config\Loader\FileLoader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  7/  7)
\Cascade\Config\Loader\FileLoader::Yaml
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  6/  6)
```

And of course with PHP 5.6.31 and PHPUnit 5.7
```
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.

................................................................. 65 / 97 ( 67%)
................................                                  97 / 97 (100%)

Time: 10.39 seconds, Memory: 16.25MB

OK (97 tests, 139 assertions)


Code Coverage Report:
  2017-10-23 19:19:50

 Summary:
  Classes: 100.00% (16/16)
  Methods: 100.00% (70/70)
  Lines:   100.00% (381/381)

\Cascade::Cascade
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 18/ 18)
\Cascade::Config
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 46/ 46)
\Cascade::Util
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  4/  4)
\Cascade\Config::ConfigLoader
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% ( 10/ 10)
\Cascade\Config\Loader::ClassLoader
  Methods: 100.00% ( 9/ 9)   Lines: 100.00% ( 73/ 73)
\Cascade\Config\Loader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader::FormatterLoader
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  6/  6)
\Cascade\Config\Loader\ClassLoader::HandlerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 69/ 69)
\Cascade\Config\Loader\ClassLoader::LoggerLoader
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 48/ 48)
\Cascade\Config\Loader\ClassLoader::ProcessorLoader
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  2/  2)
\Cascade\Config\Loader\ClassLoader\Resolver::ConstructorResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 33/ 33)
\Cascade\Config\Loader\ClassLoader\Resolver::ExtraOptionsResolver
  Methods: 100.00% ( 7/ 7)   Lines: 100.00% ( 28/ 28)
\Cascade\Config\Loader\FileLoader::FileLoaderAbstract
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 13/ 13)
\Cascade\Config\Loader\FileLoader::Json
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  9/  9)
\Cascade\Config\Loader\FileLoader::PhpArray
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  7/  7)
\Cascade\Config\Loader\FileLoader::Yaml
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  6/  6)
```

