### PR TITLE
composer: allow semver package upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
-        "php": ">=5.3.9",
-        "symfony/config": "~2.7|~3.0|~4.0",
-        "symfony/options-resolver": "~2.7|~3.0|~4.0",
-        "symfony/serializer": "~2.7|~3.0|~4.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0",
-        "monolog/monolog": "~1.13"
+        "php": "^5.3.9 || ^7.0",
+        "symfony/config": "^2.7 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
+        "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
+        "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
+        "monolog/monolog": "^1.13"
     },
     "autoload": {
         "psr-4": {
@@ -31,11 +31,11 @@
         }
     },
     "require-dev": {
-        "mikey179/vfsStream": "~1.6",
-        "phpunit/phpcov": "~2.0",
-        "phpunit/phpunit": "~4.8",
-        "satooshi/php-coveralls": "~1.0",
-        "squizlabs/php_codesniffer": "~2.5"
+        "mikey179/vfsStream": "^1.6",
+        "phpunit/phpcov": "^2.0",
+        "phpunit/phpunit": "^4.8",
+        "satooshi/php-coveralls": "^1.0",
+        "squizlabs/php_codesniffer": "^2.5"
     },
     "prefer-stable": true,
     "extra": {


### PR DESCRIPTION
the symfony 4.x support was done incorrectly in #81.

it will not allow 4.1 and 4.2 even symfony quarantees compatibility.
the same way 2.8 and 2.9 versions were blacklisted due use of incorrect operator.

please make `0.6.0` release after the merge, so i don't end up having `dev-master` dependency in my project.

cc @jessmchung 