### PR TITLE
Curly braces to get the char from string became deprecated in PHP7.4

### DIFF
--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -51,7 +51,7 @@ class Json extends FileLoaderAbstract
     {
         return (
             !empty($string) &&
-            ($string{0} === '[' || $string{0} === '{')
+            ($string[0] === '[' || $string[0] === '{')
         );
     }
 


### PR DESCRIPTION
Hi!

After update to PHP7.4.2 I caught the " Deprecated: Array and string offset access syntax with curly braces is deprecated". https://wiki.php.net/rfc/deprecate_curly_braces_array_access