### PR TITLE
SEC-4336 : Remove deprecated syntax from vendor package monolog-cascade.

### DIFF
--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -51,7 +51,7 @@ class Json extends FileLoaderAbstract
     {
         return (
             !empty($string) &&
-            ($string{0} === '[' || $string{0} === '{')
+            ($string[0] === '[' || $string[0] === '{')
         );
     }
 


### PR DESCRIPTION
Fixed deprecated syntax error from vendor package monolog-cascade.
@bhavinrshah :- Please review.