### PR TITLE
Allow symfony 5.x packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": "^5.3.9 || ^7.0",
-        "symfony/config": "^2.7 || ^3.0 || ^4.0",
-        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
-        "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
-        "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
+        "symfony/config": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "monolog/monolog": "^1.13"
     },
     "autoload": {


### PR DESCRIPTION
Symfony [5.0] was released in November 2019, [5.1] in May 2020.

[5.0]: https://symfony.com/releases/5.0
[5.1]: https://symfony.com/releases/5.1