### PR TITLE
Fixed Travis CI + updated deprecated composer packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 env:
   global:
     - COVERALLS=0
@@ -11,19 +9,20 @@ matrix:
     include:
         - php: 5.3
           dist: precise
+          env: COMPOSER_MEMORY_LIMIT=-1
         - php: 5.4
-          env: COVERALLS=1 PHPCS=1
+          dist: trusty
         - php: 5.5
+          dist: trusty
         - php: 5.6
+          env: COVERALLS=1 PHPCS=1
         - php: 7
-        - php: hhvm
-        # - php: 5.4
-        # env: PHPCS=0 DEFAULT=1
 
     allow_failures:
-        # allow failure for Php > 5.6
-        - php: 7
-        - php: hhvm
+        # allow failure for Php < 5.6
+        - php: 5.3
+        - php: 5.4
+        - php: 5.5
     fast_finish: true
 
 install:
@@ -35,3 +34,5 @@ script:
 
 after_script:
     - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/coveralls -vvv ; fi"
+
+

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
         }
     },
     "require-dev": {
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "phpunit/phpcov": "^2.0",
         "phpunit/phpunit": "^4.8",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "prefer-stable": true,


### PR DESCRIPTION
- Added dist to handle corresponding Php version
- Removed deprecated key in `.travis.yml`
- Fixed deprecation notices for `vfsstream` and `php-coveralls` packages
- Moved coverage generation for Php 5.6
- Dropped HHVM support in Travis
- Allow build failure for Php < 5.6