### PR TITLE
Upgrade to PHPUnit 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
-        "php": "^5.3.9 || ^7.0",
+        "php": ">=7.2",
         "symfony/config": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0",
@@ -32,8 +32,8 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpcov": "^2.0",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpcov": "^6.0",
+        "phpunit/phpunit": "^8.5",
         "php-coveralls/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^2.5"
     },

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -14,15 +14,16 @@ use Monolog\Logger;
 use Monolog\Registry;
 
 use Cascade\Cascade;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CascadeTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class CascadeTest extends \PHPUnit_Framework_TestCase
+class CascadeTest extends TestCase
 {
-    public function teardown()
+    public function teardown(): void
     {
         Registry::clear();
         parent::teardown();

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -48,11 +48,10 @@ class CascadeTest extends TestCase
         $this->assertSame($logger, $logger2);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRegistryWithInvalidName()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         Cascade::getLogger(null);
     }
 

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -12,13 +12,14 @@ namespace Cascade\Tests\Config;
 
 use Cascade\Config\ConfigLoader;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
+class ConfigLoaderTest extends TestCase
 {
     /**
      * Loader to test against
@@ -26,13 +27,13 @@ class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
      */
     protected $loader = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setup();
         $this->loader = new ConfigLoader();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->loader = null;
         parent::tearDown();

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -11,18 +11,19 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormatterLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
+class FormatterLoaderTest extends TestCase
 {
     /**
      * Set up function
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         new FormatterLoader(array());
@@ -31,7 +32,7 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down function
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         FormatterLoader::$extraOptionHandlers = array();
         parent::tearDown();

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -245,8 +245,14 @@ class HandlerLoaderTest extends TestCase
     {
         $options = array();
 
-        $mockProcessor1 = '123';
-        $mockProcessor2 = '456';
+        $mockProcessor1 = function($record) {
+            $record['extra']['dummy'] = 'Hello world 1!';
+            return $record;
+        };
+        $mockProcessor2 = function($record) {
+            $record['extra']['dummy'] = 'Hello world 1!';
+            return $record;
+        };
         $processorsArray = array($mockProcessor1, $mockProcessor2);
 
         // Setup mock and expectations

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -13,13 +13,14 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 use Monolog\Formatter\LineFormatter;
 
 use Cascade\Config\Loader\ClassLoader\HandlerLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class HandlerLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
+class HandlerLoaderTest extends TestCase
 {
     public function testHandlerLoader()
     {

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -54,11 +54,10 @@ class HandlerLoaderTest extends TestCase
         $this->assertEquals($original, $options);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHandlerLoaderWithInvalidFormatter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $options = array(
             'formatter' => 'test_formatter'
         );
@@ -67,11 +66,10 @@ class HandlerLoaderTest extends TestCase
         $loader = new HandlerLoader($options, $formatters);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHandlerLoaderWithInvalidProcessor()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $dummyClosure = function () {
             // Empty function
         };
@@ -84,11 +82,10 @@ class HandlerLoaderTest extends TestCase
         $loader = new HandlerLoader($options, $formatters, $processors);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHandlerLoaderWithInvalidHandler()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $dummyClosure = function () {
             // Empty function
         };
@@ -102,11 +99,10 @@ class HandlerLoaderTest extends TestCase
         $loader = new HandlerLoader($options, $formatters, $processors, $handlers);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHandlerLoaderWithInvalidHandlers()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $dummyClosure = function () {
             // Empty function
         };

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -57,11 +57,10 @@ class LoggerLoaderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testResolveHandlersWithMismatch()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $options = array(
             'handlers' => array('unexisting_handler', 'test_handler_2')
         );
@@ -96,11 +95,10 @@ class LoggerLoaderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testResolveProcessorsWithMismatch()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $dummyClosure = function () {
             // Empty function
         };

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -15,18 +15,19 @@ use Monolog\Logger;
 use Monolog\Registry;
 
 use Cascade\Config\Loader\ClassLoader\LoggerLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class LoggerLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
+class LoggerLoaderTest extends TestCase
 {
     /**
      * Tear down function
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Registry::clear();

--- a/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
@@ -13,13 +13,14 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 use Monolog\Processor\WebProcessor;
 
 use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ProcessorLoaderTest
  *
  * @author Kate Burdon <kburdon@tableau.com>
  */
-class ProcessorLoaderTest extends \PHPUnit_Framework_TestCase
+class ProcessorLoaderTest extends TestCase
 {
     public function testProcessorLoader()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
+use PHPUnit\Framework\TestCase;
 use Symfony;
 
 /**
@@ -20,7 +21,7 @@ use Symfony;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
+class ConstructorResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options
@@ -37,7 +38,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Set up function
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->class = 'Cascade\Tests\Fixtures\SampleClass';
         $this->resolver = new ConstructorResolver(new \ReflectionClass($this->class));
@@ -47,7 +48,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down function
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->resolver = null;
         $this->class = null;

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -15,6 +15,8 @@ use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
 use PHPUnit\Framework\TestCase;
 use Symfony;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 /**
  * Class ConstructorResolverTest
@@ -184,10 +186,11 @@ class ConstructorResolverTest extends TestCase
      *
      * @param  array $incompleteOptions Array of invalid options
      * @dataProvider missingOptionsProvider
-     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
     public function testResolveWithMissingOptions(array $incompleteOptions)
     {
+        $this->expectException(MissingOptionsException::class);
+
         $this->resolver->resolve($incompleteOptions);
     }
 
@@ -223,10 +226,11 @@ class ConstructorResolverTest extends TestCase
      *
      * @param  array $invalidOptions Array of invalid options
      * @dataProvider invalidOptionsProvider
-     * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testResolveWithInvalidOptions($invalidOptions)
     {
+        $this->expectException(UndefinedOptionsException::class);
+
         $this->resolver->resolve($invalidOptions);
     }
 }

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -14,6 +14,7 @@ use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
 
 use PHPUnit\Framework\TestCase;
 use Symfony;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 /**
  * Class ExtraOptionsResolverTest
@@ -169,10 +170,11 @@ class ExtraOptionsResolverTest extends TestCase
      *
      * @param  array $invalidOptions Array of invalid options
      * @dataProvider invalidOptionsProvider
-     * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testResolveWithInvalidOptions($invalidOptions)
     {
+        $this->expectException(UndefinedOptionsException::class);
+
         $this->resolver->resolve($invalidOptions);
     }
 }

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
 
+use PHPUnit\Framework\TestCase;
 use Symfony;
 
 /**
@@ -19,7 +20,7 @@ use Symfony;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
+class ExtraOptionsResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options
@@ -36,7 +37,7 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Set up function
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->class = 'Cascade\Tests\Fixtures\SampleClass';
         $this->params = array('optionalA', 'optionalB');
@@ -50,7 +51,7 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down function
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->resolver = null;
         $this->class = null;

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader;
 use Cascade\Config\Loader\ClassLoader;
 use Cascade\Tests\Fixtures\DependentClass;
 use Cascade\Tests\Fixtures\SampleClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ClassLoaderTest
@@ -20,12 +21,12 @@ use Cascade\Tests\Fixtures\SampleClass;
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  * @author Dom Morgan <dom@d3r.com>
  */
-class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassLoaderTest extends TestCase
 {
     /**
      * Set up function
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -33,7 +34,7 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Tear down function
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ClassLoader::$extraOptionHandlers = array();
         parent::tearDown();

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -10,6 +10,8 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\FileLocatorInterface;
 use org\bovigo\vfs\vfsStream;
@@ -21,15 +23,15 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
+class FileLoaderAbstractTest extends TestCase
 {
     /**
      * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var MockObject
      */
     protected $mock = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -47,7 +49,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
         \FileLoaderAbstractMockClass::$validExtensions = array('test', 'php');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->mock = null;
         parent::tearDown();

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -152,11 +152,11 @@ class FileLoaderAbstractTest extends TestCase
 
     /**
      * Test loading an invalid file
-     *
-     * @expectedException \RuntimeException
      */
     public function testloadFileFromInvalidFile()
     {
+        $this->expectException(\RuntimeException::class);
+
         // mocking the file system from a 'config_dir' base dir
         $root = vfsStream::setup('config_dir');
 

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -35,9 +35,8 @@ class FileLoaderAbstractTest extends TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
-            'Symfony\Component\Config\FileLocatorInterface'
-        );
+        $fileLocatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')
+                                ->getMock();
 
         $this->mock = $this->getMockForAbstractClass(
             'Cascade\Config\Loader\FileLoader\FileLoaderAbstract',

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -11,21 +11,23 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class JsonTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     /**
      * JSON loader mock builder
-     * @var \PHPUnit_Framework_MockObject_MockBuilder
+     * @var MockBuilder
      */
     protected $jsonLoader = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -41,7 +43,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
             ->getMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->jsonLoader = null;
         parent::tearDown();

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -31,9 +31,8 @@ class JsonTest extends TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
-            'Symfony\Component\Config\FileLocatorInterface'
-        );
+        $fileLocatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')
+                                ->getMock();
 
         $this->jsonLoader = $this->getMockBuilder(
             'Cascade\Config\Loader\FileLoader\Json'

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -43,11 +43,10 @@ class PhpArrayTest extends TestCase
         $this->assertFalse($this->loader->supports(__DIR__.'/../../../Fixtures/fixture_config.json'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsExceptionWhenLoadingFileIfDoesNotReturnValidPhpArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->loader->load(__DIR__.'/../../../Fixtures/fixture_invalid_config.php');
     }
 

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -7,6 +7,7 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 
 use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
@@ -14,19 +15,19 @@ use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
 /**
  * Class PhpArrayTest
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * @var ArrayLoader
      */
     protected $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new ArrayLoader(new FileLocator());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->loader = null;
     }

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -33,9 +33,8 @@ class YamlTest extends TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
-            'Symfony\Component\Config\FileLocatorInterface'
-        );
+        $fileLocatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')
+                                ->getMock();
 
         $this->yamlLoader = $this->getMockBuilder(
             'Cascade\Config\Loader\FileLoader\Yaml'

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -10,6 +10,8 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
 use Cascade\Tests\Fixtures;
@@ -19,15 +21,15 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class YamlTest extends \PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     /**
      * Yaml loader mock builder
-     * @var \PHPUnit_Framework_MockObject_MockBuilder
+     * @var MockBuilder
      */
     protected $yamlLoader = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +45,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
             ->getMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->yamlLoader = null;
         parent::tearDown();

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -12,13 +12,14 @@ namespace Cascade\Tests\Config\Loader;
 
 use Cascade\Config\Loader\PhpArray as ArrayLoader;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PhpArrayTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * Array loader object
@@ -26,14 +27,14 @@ class PhpArrayTest extends \PHPUnit_Framework_TestCase
      */
     protected $arrayLoader = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->arrayLoader = new ArrayLoader();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->arrayLoader = null;
         parent::tearDown();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -14,13 +14,14 @@ use Monolog\Registry;
 
 use Cascade\Config;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * Testing contructor and load functions

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -77,10 +77,11 @@ class ConfigTest extends TestCase
 
     /**
      * Test configure throwing an exception due to missing 'loggers' key
-     * @expectedException \RuntimeException
      */
     public function testConfigureWithNoLoggers()
     {
+        $this->expectException(\RuntimeException::class);
+
         $options = array();
 
         // Mocking the ConfigLoader with the load method

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -3,13 +3,14 @@
 namespace Cascade\Tests;
 
 use Cascade\Util;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigTest
  *
  * @author Deniz Dogan <deniz@dogan.se>
  */
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     public function testSnakeToCamelCase()
     {


### PR DESCRIPTION
This is required in order to run tests with Monolog 2. The changes are described in each commit.

If this PR is accepted, I will open a new one for Monolog 2 support.