### PR TITLE
Allow monolog/monolog ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "monolog/monolog": "^1.13"
+        "monolog/monolog": "^1.13 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
All my testing indicates that monolog 2 is supported by 0.6. Merging this and releasing 0.6.1 should allow people to use whichever version of monolog they prefer.

None of the instantiation done by this package should be affected by the changes: https://github.com/Seldaek/monolog/blob/main/UPGRADE.md#200

Of course, in user land, people may be using handlers in their config that monolog no longer supports.

Closes #90 