### PR TITLE
Allow monolog 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /phpunit.xml
 /vendor
 /.idea
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "monolog/monolog": "^1.13 || ^2.0"
+        "monolog/monolog": "^1.13 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,8 +32,8 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpcov": "^6.0",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpcov": "^9.0",
+        "phpunit/phpunit": "^10.0",
         "php-coveralls/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^2.5"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,12 +7,6 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
     <php>
         <ini name="date.timezone" value="UTC"/>
     </php>

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -30,7 +30,7 @@ class ConfigTest extends TestCase
     {
         $mock = $this->getMockBuilder('Cascade\Config\ConfigLoader')
             ->disableOriginalConstructor()
-            ->setMethods(array('load'))
+            ->onlyMethods(array('load'))
             ->getMock();
 
         $array = Fixtures::getSamplePhpArray();
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase
         // Mocking the ConfigLoader with the load method
         $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
             ->disableOriginalConstructor()
-            ->setMethods(array('load'))
+            ->onlyMethods(array('load'))
             ->getMock();
 
         $configLoader->method('load')->willReturn($options);
@@ -58,7 +58,7 @@ class ConfigTest extends TestCase
         // Mocking the config object and set expectations for the configure methods
         $config = $this->getMockBuilder('Cascade\Config')
             ->setConstructorArgs(array($options, $configLoader))
-            ->setMethods(array(
+            ->onlyMethods(array(
                     'configureFormatters',
                     'configureProcessors',
                     'configureHandlers',
@@ -87,7 +87,7 @@ class ConfigTest extends TestCase
         // Mocking the ConfigLoader with the load method
         $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
             ->disableOriginalConstructor()
-            ->setMethods(array('load'))
+            ->onlyMethods(array('load'))
             ->getMock();
 
         $configLoader->method('load')->willReturn($options);
@@ -95,7 +95,7 @@ class ConfigTest extends TestCase
         // Mocking the config object
         $config = $this->getMockBuilder('Cascade\Config')
             ->setConstructorArgs(array($options, $configLoader))
-            ->setMethods(null)
+            ->onlyMethods([])
             ->getMock();
 
         $config->load();
@@ -112,7 +112,7 @@ class ConfigTest extends TestCase
         // Mocking the ConfigLoader with the load method
         $configLoader = $this->getMockBuilder('Cascade\Config\ConfigLoader')
             ->disableOriginalConstructor()
-            ->setMethods(array('load'))
+            ->onlyMethods(array('load'))
             ->getMock();
 
         $configLoader->method('load')->willReturn($options);


### PR DESCRIPTION
Working with monolog 3+, monolog-cascade couldn't be installed via composer